### PR TITLE
Should properly link to machine user documentation

### DIFF
--- a/_posts/continuous-deployment/2015-04-24-push-to-remote-repository.md
+++ b/_posts/continuous-deployment/2015-04-24-push-to-remote-repository.md
@@ -11,7 +11,7 @@ categories:
 In order to push to a remote repository you need to follow these steps:
 
 - Remove the deploy key from the repository 
-- Add it to a [special user]((https://developer.github.com/guides/managing-deploy-keys/#machine-users)) and add this user to the repository.
+- Add it to a [special user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) and add this user to the repository.
 - Fetch the complete repository including any missing remote branches with the following script: 
 
 ```shell


### PR DESCRIPTION
This fixes an issue where the link to Machine Users Documentation was being treated as relative, resulting in a 404 on the Codeship documentation page.