### PR TITLE
Cache the AWS container

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -12,6 +12,7 @@ node:
     - data
 aws:
   build:
+    image: quay.io/codeship/documentation-aws
     dockerfile_path: Dockerfile.aws
   volumes_from:
     - data

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -14,6 +14,7 @@ aws:
   build:
     image: quay.io/codeship/documentation-aws
     dockerfile_path: Dockerfile.aws
+  cached: true
   volumes_from:
     - data
   encrypted_env_file: deployment.env.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -10,6 +10,7 @@
         - name: jet_release_notes
           service: aws
           command: sh bin/jet.sh
+          encrypted_dockercfg_path: dockercfg.encrypted
         - name: build
           service: docs
           command: bash bin/build.sh
@@ -27,15 +28,19 @@
     - name: s3_sync
       service: aws
       command: sh bin/s3.sh sync
+      encrypted_dockercfg_path: dockercfg.encrypted
     - name: s3_website
       service: aws
       command: sh bin/s3.sh configure_website _website.json
+      encrypted_dockercfg_path: dockercfg.encrypted
     - name: s3_lifecycle
       service: aws
       command: sh bin/s3.sh configure_lifecycle _lifecycle.json
+      encrypted_dockercfg_path: dockercfg.encrypted
     - name: s3_robots
       service: aws
       command: sh bin/s3.sh robots
+      encrypted_dockercfg_path: dockercfg.encrypted
     - name: swiftype
       service: curl
       command: sh bin/swiftype.sh


### PR DESCRIPTION
Implement caching for the AWS container. It differs from https://github.com/codeship-library/aws-deployment, because we need the `natsort` Python package to implement the automatic ChangeLog generation for Codeship CLI.