### PR TITLE
Fail builds on `master` for forked repositories

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -e
 log() { echo -e "\e[36m$@\e[39m"; }
-fail() { echo -e "\e[31m$@\e[39m"; exit 1; }
-
-# Break if we're on Codeship.com, the master branch, but not the
-# https://github.com/codeship/documentation repository
-if [ "${CI}" = "true" -a "${CI_BRANCH}" = "master" -a  "${CI_REPO_NAME}" != "codeship/documentation" ]; then
-	 fail "Builds for the master branch are only run for the codeship/documentation repository!"
-fi
 
 # Special treatment for the "master" branch to deploy to /documentation instead
 # of /master

--- a/bin/check_fork.sh
+++ b/bin/check_fork.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+fail() { echo -e "\e[31m$@\e[39m"; exit 1; }
+
+# TODO
+# currently CI_REPO_NAME only contains the repository name, but not the owner,
+# git metadata isn't available, because the .git folder is in the .dockerignore
+# file. So we only match the name for now.
+# Switch to owner/repository or the full remote URL once this is available.
+
+# Break if we're on Codeship.com, the master branch, but not the
+# https://github.com/codeship/documentation repository
+if [ "${CI}" = "true" -a "${CI_BRANCH}" = "master" -a  "${CI_REPO_NAME}" != "documentation" ]; then
+	 fail "Builds for the ${CI_BRANCH} branch are only run for the codeship/documentation repository!"
+fi

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -5,7 +5,7 @@
       name: prepare_site
       steps:
         - name: jet_release_notes
-          tag: "(master|private/docker.*)"
+          tag: "^(master|private/docker.*)"
           service: aws
           command: sh bin/jet.sh
           encrypted_dockercfg_path: dockercfg.encrypted
@@ -21,7 +21,7 @@
       command: bundle exec scss-lint
       encrypted_dockercfg_path: dockercfg.encrypted
 - type: serial
-  tag: "(master|staging/.*|private/.*)"
+  tag: "^(master|staging/.*|private/.*)"
   steps:
     - name: s3_sync
       service: aws

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -20,6 +20,10 @@
       service: docs
       command: bundle exec scss-lint
       encrypted_dockercfg_path: dockercfg.encrypted
+- name: fail_master_on_forks
+  service: docs
+  tag: master
+  command: sh bin/check_fork.sh
 - type: serial
   tag: "^(master|staging/.*|private/.*)"
   steps:


### PR DESCRIPTION
Reason being, that e.g. our `documentation-private` fork, could overwrite the master documentation with outdated information.

Also fix the RegEx for running deployments.