### PR TITLE
Docs for host volumes for deployment containers

### DIFF
--- a/_posts/docker/2015-05-25-services.md
+++ b/_posts/docker/2015-05-25-services.md
@@ -63,6 +63,46 @@ data:
 * `path` allows you specify a `custom_directory` to use as the context for building the Docker container. _Note_, that the _Dockerfile_ is searched for relative to that directory. If you don't specify this option, it will default to the directory of the services file.
 * `dockerfile_path` allows you to specify a file name as opposed to a directory name. This is useful for having multiple _Dockerfile_'s in the same directory.
 
+### Using artifacts created earlier in the build
+
+When building containers for deployment you want to make sure that you're installing exactly what is necessary for running the container in production and nothing more. Any additional tool or dependency makes the container unnecessarily big and can lead to potential issues in the future.
+
+The best way to accomplish this is to separate the container that is building the artifact from the one running it in the future.
+
+At first we're setting up two different services, one to compile our artifact and one to build the deployable container. In the container for compiling our artifact we're sharing the `tmp` folder in our repository checkout as `/artifacts` in the container. After building the artifact we can copy the results into `/artifacts` which will make them available in the `tmp` folder for building the deployment container. The deployment container gets built through `Dockerfile.deploy`.
+
+```yaml
+compile:
+  image: compileimage:latest
+  volumes:
+    - ./tmp:/artifacts
+deploy:
+  build:
+    image: deploymentcontainer
+    dockerfile_path: Dockerfile.deploy
+```
+
+To create our artifact we're first running `build_artifact.sh`. To trigger the building of the deploy container we're simply running `true` so the container gets built.
+
+```yaml
+- service: compile
+  command: "./build_artifact.sh"
+- service: deploy
+  command: true
+```
+
+In the Dockerfile for the deployment we're copying the artifact that was created in the fist step in to the container. Now we have a finished container that can be deployed to production.
+
+```Dockerfile
+FROM busybox
+
+RUN mkdir -p /app
+WORKDIR /app
+ADD ./tmp/artifact /app/artifact
+```
+
+We have an [example in our codeship/codeship-tool-examples](https://github.com/codeship/codeship-tool-examples/tree/master/8.deployment-container) repository as well. You can read more about how to set up host volumes in our [volumes documentation]({{ site.baseurl }}{% post_url docker/tutorials/2015-09-04-docker-volumes %}). For more insight into best practices for building containers take a look at the [Docker documentation pages](https://docs.docker.com/articles/dockerfile_best-practices/) covering it.
+
 ## Environment Variables
 
 The standard `environment` and `env_file` directives are supported. Additionally, we support encrypted environment variables

--- a/_posts/docker/2015-05-25-services.md
+++ b/_posts/docker/2015-05-25-services.md
@@ -82,7 +82,7 @@ deploy:
     dockerfile_path: Dockerfile.deploy
 ```
 
-To create our artifact we're first running `build_artifact.sh`. To trigger the building of the deploy container we're simply running `true` so the container gets built.
+To create our artifact we're first running `build_artifact.sh` which is part of your repository. To trigger the building of the deploy container we're simply running `true` so the container gets built.
 
 ```yaml
 - service: compile
@@ -91,9 +91,10 @@ To create our artifact we're first running `build_artifact.sh`. To trigger the b
   command: true
 ```
 
-In the Dockerfile for the deployment we're copying the artifact that was created in the fist step in to the container. Now we have a finished container that can be deployed to production.
+In `Dockerfile.deploy` we're copying the artifact that was created in the fist step in to the container. Now we have a finished container that can be deployed to production.
 
 ```Dockerfile
+# Dockerfile.deploy
 FROM busybox
 
 RUN mkdir -p /app


### PR DESCRIPTION
To build minimal deployment containers you want to separate
building the artifact from building the deployment containers.
This gets documented here now.