### PR TITLE
Add flag in docs to run the maven build in batch mode

### DIFF
--- a/_posts/docker/languages/2015-08-28-java.md
+++ b/_posts/docker/languages/2015-08-28-java.md
@@ -112,7 +112,7 @@ Now we're going to set up our `codeship-steps.yml` file. Every step in a build g
 ```yaml
 - name: ci
   service: project_name
-  command: mvn test
+  command: mvn test -B
 ```
 
 ### Gradle


### PR DESCRIPTION
To avoid logging messages when dependencies are being downloaded, the batch mode maven flag can be used. 
In the service definition file, the flag is already added, but in the steps file it was missing