### PR TITLE
Use system libraries for Nokogiri on Ruby 2.3

### DIFF
--- a/_posts/languages/2014-09-03-ruby.md
+++ b/_posts/languages/2014-09-03-ruby.md
@@ -35,6 +35,14 @@ If you install a version not preinstalled on the VM already, you need to install
 gem install bundler
 ```
 
+## Nokogiri
+On **Ruby 2.3 only**, Nokogiri will fail to compile with the bundled _libxml_ and _libxslt_ libraries. To install the gem you need to use the system libraries instead.
+
+```
+# add the following command before running "bundle install"
+bundle config build.nokogiri --use-system-libraries
+```
+
 ## Supported Test Frameworks
 We support all Ruby based test frameworks from RSpec, Cucumber to Minitest or others.
 


### PR DESCRIPTION
Explain how to install Nokogiri when using Ruby 2.3 using the system libraries and not the bundled versions.