### PR TITLE
Adding issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,12 @@
+Please don't create new issues on this repository when you experience issues with your builds on https://codeship.com, want to request new features for the CI system orhave general questions on how to use https://codeship.com for your projects.
+ 
+In all of the above cases, reach out to our support team at support@codeship.com or on Twitter at [@CodeshipSupport](https://twitter.com/CodeshipSupport).
+
+If you are reporting an error in the documentation, please include the following:
+
+- Exact location of error
+- Proposed change, if any
+- If the documention error results in an error in your project, please include any relevant logs.
+ 
+Thanks! 🚢
+


### PR DESCRIPTION
Adding a template to gently remind people not to open GitHub issues for support requests. The text comes from the existing Guidelines for Contributing document.