### PR TITLE
Rework how to cache Python 3 dependencies

### DIFF
--- a/_posts/languages/2014-09-03-python.md
+++ b/_posts/languages/2014-09-03-python.md
@@ -20,6 +20,6 @@ pip install -r requirements.txt
 As the virtual environment from `${HOME}/.virtualenv` is already activated and configured for use on the build VMs, if you want to switch to version 3, simply add the following commands to your _Setup Steps_.
 
 ```shell
-rm -rf ${HOME}/.virtualenv
-virtualenv -p $(which python3) "${HOME}/.virtualenv"
+virtualenv -p $(which python3) "${HOME}/cache/python3_env"
+source "${HOME}/cache/python3_env/bin/activate"
 ```


### PR DESCRIPTION
removing the old virtual environment caused the dependency cache to break beacuse of a missing folder.