### PR TITLE
Fix a typo in the Docker Ruby tutorial

### DIFF
--- a/_posts/docker/languages/2015-08-27-ruby.md
+++ b/_posts/docker/languages/2015-08-27-ruby.md
@@ -129,7 +129,7 @@ COMMAND=${1:?'You need to pass a command as the first parameter!'}
 bundle exec rake db:create db:migrate
 
 case $COMMAND in
-spec)
+specs)
   bundle exec rspec spec
   ;;
 features)


### PR DESCRIPTION
The steps file mentioend a `specs` task, but the shell script defined the task as `spec`.