### PR TITLE
Fix the notice being displayed as a code block

### DIFF
--- a/_posts/docker/tutorials/2015-09-07-caching.md
+++ b/_posts/docker/tutorials/2015-09-07-caching.md
@@ -13,9 +13,9 @@ categories:
 {:toc}
 
 <div class="info-block">
-    A change to the way Docker addresses content in the latest release (1.10.x) completely broke caching using the mechanism we implemented. We're currently looking into alternative ways to provide cache images.
+A change to the way Docker addresses content in the latest release (1.10.x) completely broke caching using the mechanism we implemented. We're currently looking into alternative ways to provide cache images.
 
-    Please see [docker/docker#20316](https://github.com/docker/docker/issues/20316) for the original issue as well as a more detailed explanation.
+Please see [docker/docker#20316](https://github.com/docker/docker/issues/20316) for the original issue as well as a more detailed explanation.
 </div>
 
 ## Using Caching


### PR DESCRIPTION
Fixes the issue with the codeblock in the info block on https://codeship.com/documentation/docker/caching/