### PR TITLE
Fix deployment regex

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -29,7 +29,7 @@
   tag: master
   command: sh bin/check_fork.sh
 - type: serial
-  tag: "^(master|staging/.*|private/.*)"
+  tag: "^(master|staging/.*|private/.*)$"
   steps:
     - name: s3_sync
       service: aws


### PR DESCRIPTION
Don't run the deployment on branches starting with master