### PR TITLE
Embed discourse comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,10 @@ permalink: /:categories/:title/
 tags_dir: tags
 ubuntu_version: trusty
 
+# Discourse Comments
+# See https://github.com/oblakeerickson/jekyll_discourse_comments
+discourse_url: "https://community.codeship.com/"
+
 # Defaults for posts
 defaults:
   -

--- a/_plugins/discourse_comments.rb
+++ b/_plugins/discourse_comments.rb
@@ -1,0 +1,50 @@
+# Discourse Comments for Jekyll
+#
+# Generates Discourse comments for posts
+#
+# Author: Blake Erickson, Justin Gordon
+# Site: http://blakeerickson.com, http://www.railsonmaui.com
+# Plugin Source: http://github.com/oblakeerickson/jekyll_discourse_comments
+# Plugin License: MIT
+
+module Jekyll
+
+  class DiscourseComments < Generator
+
+    def generate(site)
+      @site = site
+
+      process_posts
+    end
+
+    def process_posts
+      @site.posts.each do |post|
+        post.content += snippet(post.url)
+      end
+    end
+
+    def snippet(url)
+      <<-EOF.unindent
+
+        <div id="discourse-comments"></div>
+        <script type="text/javascript">
+          var discourseUrl = "#{File.join(@site.config['discourse_url'], '')}",
+              discourseEmbedUrl = "#{@site.config['url']}#{@site.config['baseurl']}#{url}";
+
+          (function() {
+            var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+              d.src = discourseUrl + 'javascripts/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+          })();
+        </script>
+      EOF
+    end
+  end
+
+end
+
+class String
+  def unindent
+    gsub(/^#{scan(/^\s*/).min_by{|l|l.length}}/, "")
+  end
+end


### PR DESCRIPTION
This PR embeds discourse comments into our documentation site.

Along with this PR we will need to add `community.codeship.com` as our embeddable host.  This setting can be found under **Admin > Customize > Embedding** of our our discourse install. You can refer to this [post](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963) for more information.