### PR TITLE
Link to Jet Installation page from Docker Tutorials

### DIFF
--- a/_posts/docker/tutorials/2015-07-03-docker-push.md
+++ b/_posts/docker/tutorials/2015-07-03-docker-push.md
@@ -14,6 +14,10 @@ categories:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
 ## Pushing to a locally running registry
 
 Please see the [example in the codeship-tool examples repository](https://github.com/codeship/codeship-tool-examples/tree/master/16.docker_push) for how to run a registry during the build process and push a new image to this registry.

--- a/_posts/docker/tutorials/2015-08-12-docker-pull.md
+++ b/_posts/docker/tutorials/2015-08-12-docker-pull.md
@@ -11,6 +11,13 @@ categories:
   - docker
 ---
 
+* include a table of contents
+{:toc}
+
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
 ## Using private images in your builds
 
 `jet` does support using private Docker images as base images for your containers. Similar to [pushing images]({{ site.baseurl }}{% post_url docker/tutorials/2015-07-03-docker-push %}) you need to save your encrypted `.dockercfg` file in the repository and reference it for any step using private base images (or for groups of steps).

--- a/_posts/docker/tutorials/2015-09-04-docker-volumes.md
+++ b/_posts/docker/tutorials/2015-09-04-docker-volumes.md
@@ -12,6 +12,10 @@ categories:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
 ## Using Docker volumes
 
 Volumes can be used to connect containers in your build environment, and to share build artifacts between containers and steps in your pipeline.

--- a/_posts/docker/tutorials/2015-09-07-caching.md
+++ b/_posts/docker/tutorials/2015-09-07-caching.md
@@ -12,6 +12,10 @@ categories:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
 ## Using Caching
 
 Please see the [example in the codeship-tool examples repository](https://github.com/codeship/codeship-tool-examples/tree/master/17.caching) of how to use caching.

--- a/_posts/docker/tutorials/2015-09-14-ssh-key-authentication.md
+++ b/_posts/docker/tutorials/2015-09-14-ssh-key-authentication.md
@@ -11,6 +11,14 @@ categories:
   - docker
 ---
 
+* include a table of contents
+{:toc}
+
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
+
 During your build you might want to access other repositories to pull in dependencies or push your code to other servers.
 
 To do this you need to set up an encrypted SSH Key that is available as an environment variable and can be written to the `.ssh` folder.
@@ -31,7 +39,7 @@ Now you have to copy the content of `keyfile.rsa` into an environment file `sshk
 PRIVATE_SSH_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCFgEA2LcSb6INQUVZZ0iZJYYkc8dMHLLqrmtIrzZ...
 ```
 
-After preparing the `sshkey.env` file we can encrypt it with jet. Follow the [encryption tutorial]({{ site.baseurl }}{% post_url docker/tutorials/2015-09-15-encryption %}) to turn the `sshkey.env` file into a `sshkey.env.encrypted` file.
+After preparing the `sshkey.env` file we can encrypt it with Jet. Follow the [encryption tutorial]({{ site.baseurl }}{% post_url docker/tutorials/2015-09-15-encryption %}) to turn the `sshkey.env` file into a `sshkey.env.encrypted` file.
 
 You can then add it to a service with the `encrypted_env_file` option. It will be automatically decrypted on Codeship.
 

--- a/_posts/docker/tutorials/2015-09-15-encryption.md
+++ b/_posts/docker/tutorials/2015-09-15-encryption.md
@@ -12,8 +12,11 @@ categories:
 
 If you need to make private information available to your build, you can save this information encrypted in your repository. This is most often needed to either make credentials used during deployment available or store credentials for a Docker registry. See e.g our [Docker Push]({{ site.baseurl }}{% post_url docker/tutorials/2015-07-03-docker-push %}) tutorial for a practical example.
 
+* include a table of contents
+{:toc}
+
 <div class="info-block">
-You need to have the [Jet CLI]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}) installed on your local system for the examples below to work.
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
 </div>
 
 ## Getting the key

--- a/_posts/docker/tutorials/2015-12-17-dockercfg-services.md
+++ b/_posts/docker/tutorials/2015-12-17-dockercfg-services.md
@@ -14,13 +14,17 @@ categories:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+</div>
+
 ## Overview
 
 Codeship supports using private registries for pulling and pushing images by allowing static dockercfg credentials to be encrypted as part of your codebase. Due to an increasing number of container registry vendors using different methods to generate Docker temporary credentials, we have added support for custom dockercfg credential generation. By using a custom service within your list of Codeship services, you can integrate with a standard dockercfg generation container for your desired provider. Codeship will provide a basic set of images supporting common providers, however you will also be able to use custom images to integrate with custom registries.
 
 ## Using a service to generate Docker credentials
 
-Taking advantage of this feature is fairly simple. First off, add a service using the image for your desired registry provider to your `codeship-services.yml` file. You can add any links, environment variables or volumes you need, just like with a regular service. 
+Taking advantage of this feature is fairly simple. First off, add a service using the image for your desired registry provider to your `codeship-services.yml` file. You can add any links, environment variables or volumes you need, just like with a regular service.
 
 ```
 # codeship-services.yml
@@ -28,7 +32,7 @@ app:
   build:
     dockerfile_path: ./Dockerfile
     image: myservice.com/myuser/myapp
-myservice_generator: 
+myservice_generator:
   image: codeship/myservice-dockercfg-generator
   encrypted_env: creds.encrypted
 ```


### PR DESCRIPTION
Link to the `jet` CLI install document for each Docker tutorial referencing the CLI. Also added TOCs for those tutorials that didn't already have them enabled.

![tutorial__pushing_to_a_remote_registry___codeship_documentation](https://cloud.githubusercontent.com/assets/7791/14429917/af5b5112-ffff-11e5-8f5c-04acdbe1309f.png)
fixes #343