### PR TITLE
Jet Installation instructions for OS X via Homebrew Cask

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ trim_trailing_whitespace = false
 
 [*.scss]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.{json,yml,yaml}]
 indent_style = space

--- a/_posts/docker/jet/2015-05-25-installation.md
+++ b/_posts/docker/jet/2015-05-25-installation.md
@@ -31,11 +31,21 @@ Please follow the steps below for the operating system you are using. See the [J
 
 ### Mac OS X
 
+The `jet` CLI is now included in [Homebrew Cask](https://caskroom.github.io/). If you already have [Homebrew installed](http://brew.sh/) and the [Caskroom tapped](https://caskroom.github.io/)[^1] you can install `jet` by running the following command
+
+```bash
+brew cask install jet
+```
+
+If you don't have Homebrew installed or don't use Homebrew Cask you can install `jet` via the following commands.
+
 ```bash
 curl -SLo "jet-{{ site.data.jet.version }}.tar.gz" "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-darwin_amd64_{{ site.data.jet.version }}.tar.gz"
 tar -xC /usr/local/bin/ -f jet-{{ site.data.jet.version }}.tar.gz
 chmod u+x /usr/local/bin/jet
 ```
+
+[^1]: Instructions for tapping the _Caskroom_ are at the very bottom of the page.
 
 ### Linux
 

--- a/_sass/docs/_footnotes.scss
+++ b/_sass/docs/_footnotes.scss
@@ -1,0 +1,27 @@
+.footnote {
+  font-size: .8em;
+  text-decoration: underline;
+  background: darken($_cGrey, 5%);
+  display: inline-block;
+  padding: 0 .3em;
+  border-radius: .2em;
+}
+
+.footnotes {
+  border-top: .1rem solid $cFootnotesBg;
+  margin-top: 2.5rem;
+
+  li {
+    font-size: .9rem;
+    line-height: .9rem;
+  }
+
+  p {
+    font-size: 1em;
+    line-height: 1em;
+  }
+
+  .reversefootnote {
+    font-size: .9em;
+  }
+}

--- a/_sass/rig/_variables.scss
+++ b/_sass/rig/_variables.scss
@@ -160,3 +160,6 @@ $cWell:             rgba(0,0,0,.6);
 $cPapernote:        #6d7c8f;
 $cPapernoteBg:      #f3f6fb;
 $cPapernoteAlt:     #cfd7e3;
+
+// footnotes
+$cFootnotesBg:      $cTagBg;

--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -29,4 +29,5 @@ $cBlue:             #5A95E5;
 @import 'docs/rouge';
 @import 'docs/swift';
 @import 'docs/footer';
-@import 'docs/gist'
+@import 'docs/gist';
+@import 'docs/footnotes';


### PR DESCRIPTION
Also added support for footnotes on articles, see the following two screenshots for how they look like.

**Link to a footnote in the text**
![running_codeship_locally_for_development___codeship_documentation](https://cloud.githubusercontent.com/assets/7791/14497746/1d2f50d2-0198-11e6-82d0-c9b19c3a8552.png)

**Footnote including a link back**
![running_codeship_locally_for_development___codeship_documentation](https://cloud.githubusercontent.com/assets/7791/14495738/06c7945a-0191-11e6-8cfe-d0647f43a9c4.png)