### PR TITLE
Add ability to embed Discourse comments on the Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ defaults:
     values:
       layout: page
       weight: 50
+      comments: true
 
 # Jekyll
 exclude:

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,0 +1,11 @@
+<div id='discourse-comments'></div>
+<script type="text/javascript">
+  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/',
+                     discourseEmbedUrl: '{{ include.url }}' };
+
+  (function() {
+    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+  })();
+</script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -36,6 +36,14 @@ layout: default
       <div data-swiftype-name="body" data-swiftype-type="text" data-swiftype-index='true'>
         {{ content }}
       </div>
+
+      {% if page.comments %}
+      <div class="comments">
+        {% capture url %}{{ page.url | prepend: site.baseurl | prepend: site.url }}{% endcapture %}
+        {% include comments.html url=url %}
+      </div>
+      {% endif %}
+
     </div>
   </div>
 </div>

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -287,6 +287,10 @@ body.is-blue {
   .onPageTags {
     margin-bottom: 2rem;
   }
+
+  .comments {
+    margin-top: 4rem;
+  }
 }
 
 .ul--columnized {

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Codeship Documentation</title>
+    <description>Documentation for Codeship.com</description>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% for post in site.posts %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>
+					{{ post.excerpt | xml_escape }}
+					Read the full and up to date article at {{ post.url | prepend: site.baseurl | prepend: site.url }}
+				</description>
+        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
This superseded #371 for adding comments to the documentation pages.

## Configuration

By default comments are enabled for all posts via the defaults in `_config.yaml`. If you want to disable comments for an individual post, add the following to the YAML front matter

```
comments: false
```

Threads will be created in the [Comments / Documentation](https://community.codeship.com/c/comments/documentation) subcategory.

- [ ] Once we merged this and the changes are deployed we need to add the following feed URL to our Discourse Embed configuration.

```
https://codeship.com/documentation/feed.xml
```

## Screenshot
![skipping_builds___codeship_documentation](https://cloud.githubusercontent.com/assets/7791/14525917/3f6b5cc4-0240-11e6-9274-3777c88e009a.png)
