### PR TITLE
Update site settings to remove the www from the URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-url: https://www.codeship.com/documentation
+url: https://codeship.com/documentation
 baseurl:
 permalink: /:categories/:title/
 tags_dir: tags


### PR DESCRIPTION
We use that URL in the feed we generate, which makes Discourse point to URLs including the www instead of the actual URL without it.