### PR TITLE
Bugfix for RSS feeds used for Comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
-url: https://codeship.com/documentation
-baseurl:
+url: https://codeship.com
+baseurl: 
 permalink: /:categories/:title/
 tags_dir: tags
 ubuntu_version: trusty

--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -196,7 +196,7 @@ module Jekyll
     # Returns the location of the page or post
     def fill_location(site, page_or_post)
       loc = REXML::Element.new "loc"
-      url = site.config['url']
+      url = "#{site.config['url']}#{site.config['baseurl']}"
       loc.text = page_or_post.location_on_server(url)
 
       loc


### PR DESCRIPTION
* remove the subfolder from the URL (it's handled via the baseurl configuration entry)
* adapt the code for the sitemap to use the value from baseurl as well.