### PR TITLE
Fix 3 column layout.

### DIFF
--- a/_sass/rig/_global.scss
+++ b/_sass/rig/_global.scss
@@ -43,7 +43,6 @@ body {
   text-stroke: 0px;
   -moz-text-stroke: 0px;
   -webkit-text-stroke: 0px;
-  letter-spacing: .1em;
 
   text-align: center;
   color: $cBody;


### PR DESCRIPTION
I have no idea why, but removing the `letter-spacing` brought back the third column. 

It would be great if @codebryo could take a look in a spare minute.