### PR TITLE
Make checksum files for Jet available for download.

### DIFF
--- a/_data/jet.yml
+++ b/_data/jet.yml
@@ -1,2 +1,2 @@
 base_url: https://s3.amazonaws.com/codeship-jet-releases
-version: "0.9.5"
+version: "1.6.0"

--- a/_posts/docker/jet/2015-05-25-installation.md
+++ b/_posts/docker/jet/2015-05-25-installation.md
@@ -29,6 +29,12 @@ In order to run the _Jet_ binary on your computer, you need to have Docker insta
 
 Please follow the steps below for the operating system you are using. See the [Jet Release Notes]({{ site.baseurl }}{% post_url docker/jet/2015-07-16-release-notes %}) for the ChangeLog.
 
+See the [sha256sums]({{ site.data.jet.base_url }}/{{ site.data.jet.version }}/sha256sums) file for checksums for the latest release. To check the downloaded files on Linux / Unix based systems run the following command.
+
+```bash
+shasum -c -a 256 sha256sums
+```
+
 ### Mac OS X
 
 The `jet` CLI is now included in [Homebrew Cask](https://caskroom.github.io/). If you already have [Homebrew installed](http://brew.sh/) and the [Caskroom tapped](https://caskroom.github.io/)[^1] you can install `jet` by running the following command
@@ -42,8 +48,8 @@ The formula will install Docker as well. If you already have Docker installed, b
 If you don't have Homebrew installed or don't use Homebrew Cask you can install `jet` via the following commands.
 
 ```bash
-curl -SLo "jet-{{ site.data.jet.version }}.tar.gz" "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-darwin_amd64_{{ site.data.jet.version }}.tar.gz"
-tar -xC /usr/local/bin/ -f jet-{{ site.data.jet.version }}.tar.gz
+curl -SLO "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-darwin_amd64_{{ site.data.jet.version }}.tar.gz"
+tar -xC /usr/local/bin/ -f jet-darwin_amd64_{{ site.data.jet.version }}.tar.gz
 chmod u+x /usr/local/bin/jet
 ```
 
@@ -52,8 +58,8 @@ chmod u+x /usr/local/bin/jet
 ### Linux
 
 ```bash
-curl -SLo "jet-{{ site.data.jet.version }}.tar.gz" "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-linux_amd64_{{ site.data.jet.version }}.tar.gz"
-sudo tar -xaC /usr/local/bin -f jet-{{ site.data.jet.version }}.tar.gz
+curl -SLO "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-linux_amd64_{{ site.data.jet.version }}.tar.gz"
+sudo tar -xaC /usr/local/bin -f jet-linux_amd64_{{ site.data.jet.version }}.tar.gz
 sudo chmod +x /usr/local/bin/jet
 ```
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-log() { echo -e "\e[36m$@\e[39m"; }
+log() { echo -e "\033[36m$@\033[39m"; }
 
 # Special treatment for the "master" branch to deploy to /documentation instead
 # of /master

--- a/bin/check_fork.sh
+++ b/bin/check_fork.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-fail() { echo -e "\e[31m$@\e[39m"; exit 1; }
+fail() { echo -e "\033[31m$@\033[39m"; exit 1; }
 
 # TODO
 # currently CI_REPO_NAME only contains the repository name, but not the owner,

--- a/bin/jet.sh
+++ b/bin/jet.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-log() { echo -e "\e[36m$@\e[39m"; }
+log() { echo -e "\033[36m$@\033[39m"; }
 
 # configuration
 unset $latest_version

--- a/bin/jet.sh
+++ b/bin/jet.sh
@@ -8,10 +8,10 @@ target="/site/.jet"
 
 log "Preparing Jet release notes and current version"
 rm -rf "${target}" && mkdir -p "${target}/sync"
-aws s3 sync "s3://${JET_RELEASE_BUCKET}/" "${target}/sync" --exclude=* --include=*.changelog --quiet
+aws s3 sync "s3://${JET_RELEASE_BUCKET}/" "${target}/sync" --exclude "*" --include "*.changelog" --quiet
 
 # write the release notes
-find "${target}/sync/" -type f -not -size 0 | natsort -r | \
+find "${target}/sync/" -name "*.changelog" -type f -not -size 0 | natsort -r | \
 while read line; do
 	version=$(basename ${line} | sed -e 's/\.changelog//')
 	if [ -z "${latest_version}" ]; then

--- a/bin/s3.sh
+++ b/bin/s3.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-log() { echo -e "\e[36m$@\e[39m"; }
+log() { echo -e "\033[36m$@\033[39m"; }
 action=${1:?'You need to pass an action!'} && shift
 
 case "$action" in

--- a/bin/swiftype.sh
+++ b/bin/swiftype.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 # trigger a Swiftype recrawl of the documentation pages
-echo -e "\e[36mTrigger Swiftype recrawl\e[39m"
+log() { echo -e "\033[36m$@\033[39m"; }
+log "Trigger Swiftype recrawl."
 curl -XPUT -H 'Content-Length: 0' "https://api.swiftype.com/api/v1/engines/codeship-docs/domains/${SWIFTYPE_DOMAIN}/recrawl.json?auth_token=${SWIFTYPE_AUTH_TOKEN}"


### PR DESCRIPTION
Link to the `sha256sums` file we generate when deploying a new version of `jet` and add a paragraph on how to verify the checksums (for Linux / Unix based OSes).

* Changed the `curl` commands to use the filenames from S3 so they match the filenames in the checksum file.
* Update the default `jet` version in the configuration files to `1.6.0`, this will be overwritten during deployment by the actual current version and is only used in local testing
* Update the `log` shell functions in a minor way.

See http://documentation.codeship.com/staging/jet-checksums/docker/installation/ for a staging deployment.

Requires codeship/jet#183