### PR TITLE
Update NodeJS, include v6

### DIFF
--- a/_posts/languages/2014-09-03-nodejs.md
+++ b/_posts/languages/2014-09-03-nodejs.md
@@ -28,7 +28,9 @@ nvm install NODE_VERSION
 If the version isn't already pre-installed on the build VMs `nvm` will download the version from the official repositories and make it available to your build.
 
 ## Pre-installed versions
-We have the latest versions of the following NodeJS releases pre-installed on our build VMs: **0.8.x**, **0.9.x**, **0.10.x**, **0.11.x**, **0.12.x**, **4.x** and **5.x**.
+We have the latest versions of the following NodeJS releases pre-installed on our build VMs: `0.8.x`, `0.9.x`, `0.10.x`, `0.11.x`, `0.12.x`, `4.x`, `5.x` and `6.x`.
+
+Please note that we only install the latest version for each of those releases. You can however install any custom version via the `nvm install` command mentioned above.
 
 ## io.js
 


### PR DESCRIPTION
Add v6 to  the list of pre-installed NodeJS versions.

See https://github.com/nodejs/node/blob/master/CHANGELOG.md#2016-04-26-version-600-current-jasnell for the ChangeLog for the release.

Requires codeship/checkbot#872