### PR TITLE
Fix a bug with parameters to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN \
 COPY . ./
 
 # Serve the site
-CMD ["bundle", "exec", "jekyll", "serve", "-H 0.0.0.0", "--incremental"]
+CMD ["bundle", "exec", "jekyll", "serve", "-H", "0.0.0.0", "--incremental"]


### PR DESCRIPTION
this resulted in Jekyll exiting with the following error message: `Error:  getaddrinfo: Name or service not known`