### PR TITLE
Update Ruby based dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 source "https://rubygems.org"
 ruby "2.3.1"
 
-gem 'jekyll', '~> 3.1.2'
-gem 'rouge', '~> 1.10.0'
-gem 'sass', '~> 3.4.7'
+gem 'jekyll', '~> 3.1.5'
+gem 'rouge', '~> 1.10.1'
+gem 'sass', '~> 3.4.22'
 
 # Jekyll plugins
 gem 'jekyll-coffeescript', '~> 1.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source "https://rubygems.org"
 ruby "2.3.1"
 
-gem 'jekyll', '~> 3.1.5'
+gem 'jekyll', '~> 3.1.6'
 gem 'rouge', '~> 1.10.1'
 gem 'sass', '~> 3.4.22'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     colorator (0.1)
-    execjs (2.6.0)
+    execjs (2.7.0)
     ffi (1.9.10)
-    jekyll (3.1.5)
+    jekyll (3.1.6)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -47,7 +47,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.1.5)
+  jekyll (~> 3.1.6)
   jekyll-coffeescript (~> 1.0.1)
   jekyll-seo-tag (~> 1.4.0)
   jekyll-sitemap (~> 0.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     colorator (0.1)
     execjs (2.6.0)
     ffi (1.9.10)
-    jekyll (3.1.3)
+    jekyll (3.1.5)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -28,9 +28,9 @@ GEM
       listen (~> 3.0, < 3.1)
     kramdown (1.11.1)
     liquid (3.0.6)
-    listen (3.0.7)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9.7)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
     rake (11.1.2)
     rb-fsevent (0.9.7)
@@ -47,16 +47,16 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.1.2)
+  jekyll (~> 3.1.5)
   jekyll-coffeescript (~> 1.0.1)
   jekyll-seo-tag (~> 1.4.0)
   jekyll-sitemap (~> 0.10.0)
-  rouge (~> 1.10.0)
-  sass (~> 3.4.7)
+  rouge (~> 1.10.1)
+  sass (~> 3.4.22)
   scss_lint
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.12.1


### PR DESCRIPTION
Upgrade to [Jekyll 3.1.6](https://github.com/jekyll/jekyll/releases), staging deploy available at http://documentation.codeship.com/staging/jekyll-3.1.6/