### PR TITLE
Deploy Metadata only for the master branch

### DIFF
--- a/_lifecycle.json
+++ b/_lifecycle.json
@@ -3,6 +3,9 @@
     "ID": "staging",
     "Prefix": "staging/",
     "Status": "Enabled",
+    "AbortIncompleteMultipartUpload": {
+      "DaysAfterInitiation": 7
+    },
     "Expiration": {
       "Days": 14
     }
@@ -10,6 +13,9 @@
     "ID": "private",
     "Prefix": "private/",
     "Status": "Enabled",
+    "AbortIncompleteMultipartUpload": {
+      "DaysAfterInitiation": 7
+    },
     "Expiration": {
       "Days": 30
     }

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -35,28 +35,28 @@
   tag: "^(master|staging/.*|private/.*)$"
   encrypted_dockercfg_path: dockercfg.encrypted
   steps:
-  - name: s3_sync
-    service: aws
-    command: sh bin/s3.sh sync
-  - type: serial
-    tag: "^master$"
-    steps:
-      - name: s3_website
-        service: aws
-        command: sh bin/s3.sh configure_website _website.json
-      - name: s3_lifecycle
-        service: aws
-        command: sh bin/s3.sh configure_lifecycle _lifecycle.json
-      - name: s3_robots
-        service: aws
-        command: sh bin/s3.sh robots
-      - name: swiftype
-        service: ci
-        command: sh bin/swiftype.sh
-  - type: push
-    tag: "^master$"
-    name: push_docker_hub
-    service: documentation
-    image_name: codeship/documentation
-    image_tag: latest
-    registry: https://index.docker.io/v1/
+    - name: s3_sync
+      service: aws
+      command: sh bin/s3.sh sync
+    - type: serial
+      tag: "^master$"
+      steps:
+        - name: s3_website
+          service: aws
+          command: sh bin/s3.sh configure_website _website.json
+        - name: s3_lifecycle
+          service: aws
+          command: sh bin/s3.sh configure_lifecycle _lifecycle.json
+        - name: s3_robots
+          service: aws
+          command: sh bin/s3.sh robots
+        - name: swiftype
+          service: ci
+          command: sh bin/swiftype.sh
+    - type: push
+      tag: "^master$"
+      name: push_docker_hub
+      service: documentation
+      image_name: codeship/documentation
+      image_tag: latest
+      registry: https://index.docker.io/v1/

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -31,28 +31,25 @@
   tag: master
   command: sh bin/check_fork.sh
 - type: parallel
-  tag: "^(master|staging/.*|private/.*)$"
   name: deploying
+  tag: "^(master|staging/.*|private/.*)$"
+  encrypted_dockercfg_path: dockercfg.encrypted
   steps:
   - name: s3_sync
     service: aws
     command: sh bin/s3.sh sync
-    encrypted_dockercfg_path: dockercfg.encrypted
   - type: serial
     tag: "^master$"
     steps:
       - name: s3_website
         service: aws
         command: sh bin/s3.sh configure_website _website.json
-        encrypted_dockercfg_path: dockercfg.encrypted
       - name: s3_lifecycle
         service: aws
         command: sh bin/s3.sh configure_lifecycle _lifecycle.json
-        encrypted_dockercfg_path: dockercfg.encrypted
       - name: s3_robots
         service: aws
         command: sh bin/s3.sh robots
-        encrypted_dockercfg_path: dockercfg.encrypted
       - name: swiftype
         service: ci
         command: sh bin/swiftype.sh
@@ -63,4 +60,3 @@
     image_name: codeship/documentation
     image_tag: latest
     registry: https://index.docker.io/v1/
-    encrypted_dockercfg_path: dockercfg.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,5 +1,6 @@
 - type: parallel
   name: testing
+  encrypted_dockercfg_path: dockercfg.encrypted
   steps:
     - type: serial
       name: prepare_site
@@ -7,18 +8,15 @@
         - name: jet_release_notes
           service: aws
           command: sh bin/jet.sh
-          encrypted_dockercfg_path: dockercfg.encrypted
         - name: build
           service: ci
           command: bash bin/build.sh
-          encrypted_dockercfg_path: dockercfg.encrypted
         - name: post-process
           service: ci
           command: gulp post-process
     - type: serial
       name: linters
       service: ci
-      encrypted_dockercfg_path: dockercfg.encrypted
       steps:
         - name: SCSS
           command: bundle exec scss-lint
@@ -30,6 +28,7 @@
   service: ci
   tag: master
   command: sh bin/check_fork.sh
+  encrypted_dockercfg_path: dockercfg.encrypted
 - type: parallel
   name: deploying
   tag: "^(master|staging/.*|private/.*)$"

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -31,15 +31,16 @@
   tag: master
   command: sh bin/check_fork.sh
 - type: parallel
+  tag: "^(master|staging/.*|private/.*)$"
   name: deploying
   steps:
+  - name: s3_sync
+    service: aws
+    command: sh bin/s3.sh sync
+    encrypted_dockercfg_path: dockercfg.encrypted
   - type: serial
-    tag: "^(master|staging/.*|private/.*)$"
+    tag: "^master$"
     steps:
-      - name: s3_sync
-        service: aws
-        command: sh bin/s3.sh sync
-        encrypted_dockercfg_path: dockercfg.encrypted
       - name: s3_website
         service: aws
         command: sh bin/s3.sh configure_website _website.json


### PR DESCRIPTION
With the previous setup a deployment to e.g. `staging/feature-a` could deploy a new version of AWS lifecycle configuration and other similar metadata.

This change limits those steps to the `master` branch only.

Added some other (minor) changes

* Moved the `encrypted_dockercfg_path` directive to the group steps. That way we don't have to specify it on each step.
* Extended the AWS S3 lifecycle configuration with a new directive for deleting incomplete multipart uploads. We shouldn't need this, but AWS recommends it in their docs, and it doesn't hurt us.
* Fixed the indentation of child steps to match the other occurrences