### PR TITLE
added meta data to stop comments from being indexed and followed

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,6 +1,10 @@
+<head>
+  <meta name="robots" content="noindex, nofollow">
+</head>
+
 <div id='discourse-comments'></div>
 <script type="text/javascript">
-  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/',
+  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/embed',
                      discourseEmbedUrl: '{{ include.url }}' };
 
   (function() {

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -4,7 +4,7 @@
 
 <div id='discourse-comments'></div>
 <script type="text/javascript">
-  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/embed',
+  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/',
                      discourseEmbedUrl: '{{ include.url }}' };
 
   (function() {


### PR DESCRIPTION
google crawlers are picking up the following error from Discourse's embedded comment widget:

```
https://community.codeship.com/embed/comments?embed_url=https%3A%2F%2Fcodeship.com%2Fdocumentation%2Ftroubleshooting%2Fbuilds-are-not-triggered%2F Failed to load resource: the server responded with a status of 403 (Forbidden)
```

After browsing meta.discourse.org and the rest of the internet, the issue lies on the permission of the `embed` folder. Since we are using a hosted version of discourse, we are not able to fix it ourselves. 

### The good
As a work around so the google crawlers doesn't pick this up, I added some meta data to not index or follow the URL in this PR.


### The bad
We may not be able to track traffic from `codeship.com/documentation` when someone clicks on the **Continue Discussion** button

Source for solution:
http://www.robotstxt.org/meta.html