### PR TITLE
fix to disallow embedded scripts from googlebot

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,11 +1,8 @@
-<div id='discourse-comments'></div>
+<div id='discourse-comments'>
 <script type="text/javascript">
-  DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/',
-                     discourseEmbedUrl: '{{ include.url }}' };
-
-  (function() {
-    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-  })();
+  // displays iframe after DOM loads
+  $(document).ready(function(){
+    comments();
+  });
 </script>
+</div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,3 +46,9 @@
   for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="//cdn.mxpnl.com/libs/mixpanel-2.2.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
 mixpanel.init("a8865d62f2d6ce8257be6047d853c926");</script>
 <!-- end Mixpanel -->
+
+<!-- jQuery -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
+<!-- discourse comments js -->
+<script type="text/javascript" src="{{ site.baseurl }}/assets/js/comments.js"></script>

--- a/assets/js/comments.js
+++ b/assets/js/comments.js
@@ -1,0 +1,13 @@
+// Embedded discourse comments iframe
+function comments (){
+var includeURL = window.location.protocol + "//" + window.location.host + "/" + window.location.pathname;
+
+DiscourseEmbed = { discourseUrl: 'https://community.codeship.com/',
+                   discourseEmbedUrl: includeURL };
+
+(function() {
+  var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+  d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+  (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+})();
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /comments.js


### PR DESCRIPTION
Proposing another approach to the SEO issue. I created an external js file `comments.js`, and moved the embedded code for the discourse comment section there. This would allow me to explicitly disallow Googlebot from crawling anything in `comments.js` while still being able to call the javascript function and display the comment section as expected. 

@codebryo What do you think of this approach?