### PR TITLE
Generator tutorial -- warning about remote Docker hosts

### DIFF
--- a/_posts/docker/tutorials/2015-12-17-dockercfg-services.md
+++ b/_posts/docker/tutorials/2015-12-17-dockercfg-services.md
@@ -15,7 +15,7 @@ categories:
 {:toc}
 
 <div class="info-block">
-To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}).
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}). Note that if the generator service you select needs to write your local filesystem, you must use a local Docker host (Linux, Docker for Mac and Windows, Docker Machine with VirtualBox, etc), and not a remote Docker host.
 </div>
 
 ## Overview


### PR DESCRIPTION
Some auth generator services require access to the local filesystem in order to write the generated auth file. If you attempt to run any of these services using a remote Docker host (AWS, Digital Ocean) it will fail because it doesn't have access to write to your local host.