### PR TITLE
Don't pass --prefer-source for caching reasons

### DIFF
--- a/_posts/languages/2014-09-03-php.md
+++ b/_posts/languages/2014-09-03-php.md
@@ -62,7 +62,7 @@ pear install pear/PHP_CodeSniffer
 ### Composer
 
 ```shell
-composer install --prefer-source --no-interaction
+composer install --no-interaction
 ```
 
 #### Cache
@@ -71,6 +71,12 @@ If you want cache `composer` dependencies during builds, please add the followin
 
 ```shell
 COMPOSER_HOME=${HOME}/cache/composer
+```
+
+To make sure that the dependency cache is used by all of your dependencies, please call `composer` via the following snippet.
+
+```
+composer install --prefer-dist  --no-interaction
 ```
 
 #### GitHub API


### PR DESCRIPTION
`--prefer-source` doesn't work well in combination with the dependency cache and forces a re-install of (most) dependencies.