### PR TITLE
Fixing broken link in cache tutorial

### DIFF
--- a/_posts/docker/tutorials/2015-09-07-caching.md
+++ b/_posts/docker/tutorials/2015-09-07-caching.md
@@ -13,7 +13,7 @@ categories:
 {:toc}
 
 <div class="info-block">
-This tutorial describes the way caching works on Codeship's infrastructure during a build. For local builds using the `jet` CLI]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}), rely on the local Docker image cache.
+This tutorial describes the way caching works on Codeship's infrastructure during a build. For [local builds using the `jet` CLI]({{ site.baseurl }}{% post_url docker/jet/2015-05-25-installation %}), rely on the local Docker image cache.
 </div>
 
 ## Using Caching


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/775634/17241222/87450486-5570-11e6-9db6-737301211977.png)
