### PR TITLE
Deploy the master branch to the bucket root too

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -25,6 +25,13 @@ if [ -f "_posts/docker/jet/2015-07-16-release-notes.md" ]; then
 fi
 rm -rf "${jet_source}"
 
+if [ "${CI_BRANCH}" = "master" ]; then
+	log "Preparing for move to documentation.codeship.com"
+	log "Building with base URL /"
+	sed -i'' -e "s|^baseurl:.*|baseurl: /|" _config.yml
+	bundle exec jekyll build --destination "/site/"
+fi
+
 # Compile the site
 log "Building with base URL /${target}"
 sed -i'' -e "s|^baseurl:.*|baseurl: /${target}|" _config.yml


### PR DESCRIPTION
For the `master` branch, generate the site twice, once at the root of the destination
folder and once in the `/documentation` subfolder.

This is a preparatory step for moving the documentation from
http://codeship.com/documentation to http://documentation.codeship.com. In a further PR
we will need to update the `robots.txt` to allow robots access directly via the bucket and
the S3 website configuration to redirect switch redirects to the new location.