### PR TITLE
Build the root level version in a subdir and move

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -25,14 +25,15 @@ if [ -f "_posts/docker/jet/2015-07-16-release-notes.md" ]; then
 fi
 rm -rf "${jet_source}"
 
-if [ "${CI_BRANCH}" = "master" ]; then
-	log "Preparing for move to documentation.codeship.com"
-	log "Building with base URL /"
-	sed -i'' -e "s|^baseurl:.*|baseurl: /|" _config.yml
-	bundle exec jekyll build --destination "/site/"
-fi
-
 # Compile the site
 log "Building with base URL /${target}"
 sed -i'' -e "s|^baseurl:.*|baseurl: /${target}|" _config.yml
 bundle exec jekyll build --destination "${destination}"
+
+if [ "${CI_BRANCH}" = "master" ]; then
+	log "Preparing for move to documentation.codeship.com"
+	log "Building with base URL /"
+	sed -i'' -e "s|^baseurl:.*|baseurl: /|" _config.yml
+	bundle exec jekyll build --destination "/site/root/"
+	mv /site/root/* /site/
+fi


### PR DESCRIPTION
Building the version deployed to the root of the bucket caused an exception within Jekyll regarding stack level during the cleanup tasks.

We now build the root level version inside the `/site/root` folder and move it to the `/site` folder afterwards.

We also build the version after the version for the `/site/documentation` subfolder.