### PR TITLE
Bug/root level deployment

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,8 +5,9 @@ log() { echo -e "\033[36m$@\033[39m"; }
 # Special treatment for the "master" branch to deploy to /documentation instead
 # of /master
 target="${CI_BRANCH}"
+baseurl="/${CI_BRANCH}"
 if [ "${CI_BRANCH}" = "master" ]; then
-	target="documentation"
+	baseurl=""
 fi
 
 # Where do we want to generate the site at?
@@ -26,14 +27,13 @@ fi
 rm -rf "${jet_source}"
 
 # Compile the site
-log "Building with base URL /${target}"
-sed -i'' -e "s|^baseurl:.*|baseurl: /${target}|" _config.yml
+log "Building with base URL '${baseurl}'"
+sed -i'' -e "s|^baseurl:.*|baseurl: ${baseurl}|" _config.yml
 bundle exec jekyll build --destination "${destination}"
 
 if [ "${CI_BRANCH}" = "master" ]; then
-	log "Preparing for move to documentation.codeship.com"
-	log "Building with base URL /"
-	sed -i'' -e "s|^baseurl:.*|baseurl: /|" _config.yml
-	bundle exec jekyll build --destination "/site/root/"
-	mv /site/root/* /site/
+	log "Building legacy version for the master branch"
+	log "Building with base URL /documentation"
+	sed -i'' -e "s|^baseurl:.*|baseurl: /documentation|" _config.yml
+	bundle exec jekyll build --destination "/site/documentation/"
 fi

--- a/bin/s3.sh
+++ b/bin/s3.sh
@@ -5,12 +5,19 @@ action=${1:?'You need to pass an action!'} && shift
 
 case "$action" in
 	'sync')
-		target="${CI_BRANCH}"
-		if [ "${CI_BRANCH}" == "master" ]; then
-			target="documentation"
+		if [ "${CI_BRANCH}" = "master" ]; then
+			log "Pushing documenation to s3://${AWS_S3_BUCKET}/"
+			aws s3 sync "/site/master/" "s3://${AWS_S3_BUCKET}/" --acl public-read --follow-symlinks --exclude "documentation/*" --exclude "staging/*" --exclude "private/*" --delete
+
+			# TODO delete the next two lines, once the move once
+			# documentation.codeship.com is complete
+			log "Pushing legacy version to s3://${AWS_S3_BUCKET}/documentation/"
+			aws s3 sync "/site/documentation/" "s3://${AWS_S3_BUCKET}/documentation/" --acl public-read --follow-symlinks --delete
+		else
+			target="${CI_BRANCH}"
+			log "Pushing documenation to s3://${AWS_S3_BUCKET}/${target}/"
+			aws s3 sync "/site/${target}/" "s3://${AWS_S3_BUCKET}/${target}/" --acl public-read --follow-symlinks --delete
 		fi
-		log "Pushing documenation to s3://${AWS_S3_BUCKET}/${target}/"
-		aws s3 sync "/site/${target}/" "s3://${AWS_S3_BUCKET}/${target}/" --acl public-read --follow-symlinks --delete
 		;;
 	'configure_website')
 		log "Pushing website configuration"


### PR DESCRIPTION
# Building

* Build the master branch to the `master` subdirectory on the Docker container
* Add special handling for the `baseurl` config setting, as this is the only setting we need to change for the master builds
* Move the legacy case (deploying to the `documentation` subfolder) to the end of the build script (so it's easier to remove it)

# Deployment

* Sync the `master` subfolder with the S3 bucket root, but ignore the `documentation` (for now), `staging` and `private` subdirectories
* For master branch builds, sync the `documentation` subdirectory as well