### PR TITLE
Deploy robots.txt via standard deploy

### DIFF
--- a/bin/s3.sh
+++ b/bin/s3.sh
@@ -29,10 +29,6 @@ case "$action" in
 		config_file=${1:?'You need to pass an action!'} && shift
 		aws s3api put-bucket-lifecycle --bucket "${AWS_S3_BUCKET}" --lifecycle-configuration "file://${config_file}"
 		;;
-	'robots')
-		log "Pushing robots.txt file"
-		aws s3 cp _robots.txt "s3://${AWS_S3_BUCKET}/robots.txt" --acl public-read
-		;;
 	*)
 		log "Invalid action ${action} :("
 		exit 1

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -43,9 +43,6 @@
         - name: s3_lifecycle
           service: aws
           command: sh bin/s3.sh configure_lifecycle _lifecycle.json
-        - name: s3_robots
-          service: aws
-          command: sh bin/s3.sh robots
         - name: swiftype
           service: documentation
           command: sh bin/swiftype.sh

--- a/robots.txt
+++ b/robots.txt
@@ -7,4 +7,4 @@
 #
 # See http://www.robotstxt.org/ for more information.
 User-agent: *
-Disallow: /
+Disallow:


### PR DESCRIPTION
* Allow robots to index the site
* Move the robots.txt to a standard file and remove the special configuration. Deploy it to each staging, private or master deployment.

**Merge after switching to the [http://documentation.codeship.com] subdomain**