### PR TITLE
Redirect "docker/getting-started" to "docker-guide/getting-started"

### DIFF
--- a/_website.json
+++ b/_website.json
@@ -60,5 +60,14 @@
     "Condition": {
       "KeyPrefixEquals": "documentation/api-and-webhooks/webhooks/"
     }
+  }, {
+    "Redirect": {
+      "HostName": "documentation.codeship.com",
+      "ReplaceKeyPrefixWith": "docker-guide/getting-started/",
+      "HttpRedirectCode": "301"
+    },
+    "Condition": {
+      "KeyPrefixEquals": "docker/getting-started/"
+    }
   }]
 }


### PR DESCRIPTION
We missed a redirect from the old _Getting Started_ guide to the new one. Google still links to the old URL, so let's redirect it :)

After this is merged https://documentation.codeship.com/docker/getting-started/ should redirect to https://documentation.codeship.com/docker-guide/getting-started/