### PR TITLE
Fix code block for the API info block

### DIFF
--- a/_posts/integrations/2014-09-02-api.md
+++ b/_posts/integrations/2014-09-02-api.md
@@ -9,7 +9,7 @@ categories:
 ---
 
 <div class="info-block">
-    The API is currently only available for projects on our Classic Infrastructure and not available on Docker based projects.
+  The API is currently only available for projects on our Classic Infrastructure and not available on Docker based projects.
 </div>
 
 * include a table of contents


### PR DESCRIPTION
This removes the code block from the info section on http://documentation.codeship.com/integrations/api/