### PR TITLE
Fixing inconsistent padding top and bottom on `tag` elements

### DIFF
--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -102,10 +102,11 @@ body.is-blue {
   color: $_cWhite;
   background: darken($_cGrey, 5%);
   display: inline-block;
-  padding: .1rem .5rem;
+  padding: .5rem;
   border-radius: .2rem;
   font-size: .9rem;
   white-space: nowrap;
+  line-height: 1;
 
   &:hover {
     background: $cAnchor;


### PR DESCRIPTION
What is currently is
<img width="114" alt="screen shot 2016-10-13 at 4 28 04 pm" src="https://cloud.githubusercontent.com/assets/1226984/19355376/14293fac-9162-11e6-8012-262809fb3a56.png">

With my change
<img width="118" alt="screen shot 2016-10-13 at 4 27 54 pm" src="https://cloud.githubusercontent.com/assets/1226984/19355387/1e16d38a-9162-11e6-9e17-f1ef46d1eef6.png">
