### PR TITLE
Fix header link for docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ kramdown:
 # Prose.io
 prose:
   rooturl: '_posts'
-  siteurl: 'https://codeship.com/documentation/'
+  siteurl: 'https://documentation.codeship.com/'
   media: 'images'
   ignore:
     - index.md
@@ -86,14 +86,14 @@ prose:
         field:
           element: 'select'
           label: 'Category'
-          options: 'http://codeship.com/documentation/metadata/categories.jsonp'
+          options: 'https://documentation.codeship.com/metadata/categories.jsonp'
       - name: 'tags'
         field:
             element: 'multiselect'
             label: 'Tags'
             placeholder: 'Choose Tags'
             alterable: true
-            options: 'http://codeship.com/documentation/metadata/tags.jsonp'
+            options: 'http://documentation.codeship.com/metadata/tags.jsonp'
       - name: 'weight'
         field:
           element: 'number'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
         <a href="https://pages.codeship.com/press">Press</a>
       </li>
       <li class="flexMenu_block_item">
-        <a href="https://documentation.codeship.com/">Documentation</a>
+        <a href="{{ site.url }}">Documentation</a>
       </li>
       <li class="flexMenu_block_item">
         <a href="https://pages.codeship.com/contact-sales?utm_source=codeship-documentation&utm_medium=hp-navbar&utm_campaign=hp-navbar-contactsales">Contact Sales</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
         <a href="https://pages.codeship.com/press">Press</a>
       </li>
       <li class="flexMenu_block_item">
-        <a href="{{ site.baseurl }}">Documentations</a>
+        <a href="https://documentation.codeship.com/">Documentation</a>
       </li>
       <li class="flexMenu_block_item">
         <a href="https://pages.codeship.com/contact-sales?utm_source=codeship-documentation&utm_medium=hp-navbar&utm_campaign=hp-navbar-contactsales">Contact Sales</a>


### PR DESCRIPTION
* fix wording "Documentations" (is correct on main site)
* fix link to go to documentation homepage instead of baseurl