### PR TITLE
Update badge URL for the Documentation project

### DIFF
--- a/_posts/faq/2014-09-12-codeship-badge.md
+++ b/_posts/faq/2014-09-12-codeship-badge.md
@@ -9,7 +9,7 @@ categories:
 ---
 If you want to add a badge showing your last builds status to your ReadMe, you can find the code in the **Notification** settings of your project.
 
-![Codeship Status for codeship/documentation](https://codeship.com/projects/59a737f0-1648-0132-c4e7-72c6c37b1f6e/status?branch=master)
+![Codeship Status for codeship/documentation](https://codeship.com/projects/0bdb0440-3af5-0133-00ea-0ebda3a33bf6/status?branch=master)
 
 The raw URL for the image looks like the this:
 


### PR DESCRIPTION
The documentation page at https://documentation.codeship.com/faq/codeship-badge/ shows a _Project Not Found_ error, because the UUID for the _Documentation_ project changed when switching to the Docker Infrastructure.

This PR updates the URL with the new UUID and makes the badge shiny and green again.