### PR TITLE
Fix vw caused rounding error

### DIFF
--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -373,11 +373,11 @@ body.is-blue {
 }
 
 .Sidebar {
-  width: 20vw;
+  width: 20%;
   text-align: left;
   border-right: 1px solid $cInputBorder;
 }
 
 .Content {
-  width: 80vw;
+  width: 80%;
 }


### PR DESCRIPTION
Apparently, sometimes the browser calculates the browser width wrong when using `vw` units.
Switching to % fixes that.