### PR TITLE
Fix sidebar behavior

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,9 +9,7 @@
 
   <div class="Layout">
     {% if page.collection %}
-      <div class="Sidebar">
-        {% include sidebar.html %}
-      </div>
+      {% include sidebar.html %}
     {% endif %}
 
     <div class="Content">

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -373,11 +373,11 @@ body.is-blue {
 }
 
 .Sidebar {
-  width: 20vw;
+  width: 20%;
   text-align: left;
   border-right: 1px solid $cInputBorder;
 }
 
 .Content {
-  width: 80vw;
+  width: 80%;
 }


### PR DESCRIPTION
I fixed the behavior of the page sometimes to break.
The Main reason seems to be that there was a critical `.Sidebar` element wrapped in another `.Sidebar` element.

Fixed and verified.