### PR TITLE
Add Instagram Link in Footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -56,6 +56,11 @@
       </a>
     </li>
     <li>
+      <a target="_blank" href="https://www.instagram.com/codeship/">
+        <span class="icon fa fa-instagram"></span>Instagram
+      </a>
+    </li>
+    <li>
       <a target="_blank" href="https://plus.google.com/104419910257777182146/posts">
         <span class="icon fa fa-google-plus"></span>Google +
       </a>


### PR DESCRIPTION
* noticed that Codeship logo isn't in docs footer (taking care of that another time)