### PR TITLE
Hide tags on the documentation pages

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,9 +1,2 @@
 <div class="meta">
-  {% if include.tags %}
-  <div class="meta__right">
-    <ul class="tagList">
-      {% for tag in include.tags %}<li><a class="tag" href="{{tag | tag_url }}">#{{ tag | downcase }}</a></li>{% endfor %}
-    </ul>
-  </div>
-  {% endif %}
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,11 +23,6 @@ layout: default
     <div class="colxs100 pageContent">
 
       <h1 class="pageTitle" data-swiftype-name="title" data-swiftype-type="string"  data-swiftype-index='true'>{{ title }}</h1>
-      {% if page.tags %}
-      <div class="hidden-on-md hidden-on-lg onPageTags">
-        {% for tag in page.tags %}<a class="tag" href="{{tag | tag_url }}">#{{ tag | downcase }}</a>{% endfor %}
-      </div>
-      {% endif %}
 
       <div data-swiftype-name="body" data-swiftype-type="text" data-swiftype-index='true'>
         {{ content }}


### PR DESCRIPTION
Tags are still included in meta tags and used by Swiftype, but don't show up for the user.

Reason being that Jekyll doesn't support tags for arbitrary collections and we can't generate tag overview pages at the moment.