### PR TITLE
Lots of redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sass', '~> 3.4.22'
 gem 'jekyll-coffeescript', '~> 1.0.1'
 gem 'jekyll-seo-tag', '~> 2.0.0'
 gem 'jekyll-sitemap', '~> 0.11.0'
+gem 'jekyll-redirect-from', '~> 0.11.0'
 
 group :test do
   gem 'scss_lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
+    jekyll-redirect-from (0.11.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
     jekyll-seo-tag (2.0.0)
@@ -56,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.3.0)
   jekyll-coffeescript (~> 1.0.1)
+  jekyll-redirect-from (~> 0.11.0)
   jekyll-seo-tag (~> 2.0.0)
   jekyll-sitemap (~> 0.11.0)
   rouge (~> 1.10.1)
@@ -66,4 +69,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/_classic/continuous-deployment/deployment-to-anynines.md
+++ b/_classic/continuous-deployment/deployment-to-anynines.md
@@ -1,9 +1,11 @@
 ---
 title: Deploy to anynines
 tags:
-- deployment
-- anynines
+  - deployment
+  - anynines
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-anynines/
 ---
 
 [anynines](http://www.anynines.com) is a PaaS built on top of CloudFoundry and OpenStack.

--- a/_classic/continuous-deployment/deployment-to-aws-codedeploy.md
+++ b/_classic/continuous-deployment/deployment-to-aws-codedeploy.md
@@ -6,6 +6,8 @@ tags:
   - amazon
   - codedeploy
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-aws-codedeploy/
 ---
 
 ## General

--- a/_classic/continuous-deployment/deployment-to-aws-lambda.md
+++ b/_classic/continuous-deployment/deployment-to-aws-lambda.md
@@ -6,6 +6,8 @@ tags:
   - amazon
   - lambda
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-aws-lambda/
 ---
 
 

--- a/_classic/continuous-deployment/deployment-to-cloudfoundry.md
+++ b/_classic/continuous-deployment/deployment-to-cloudfoundry.md
@@ -1,9 +1,11 @@
 ---
 title: Deploy with Cloud Foundry
 tags:
-- deployment
-- cloudfoundry
+  - deployment
+  - cloudfoundry
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-cloudfoundry/
 ---
 
 As for getting started with **Cloud Foundry** on Codeship, start by getting your application to deploy from your local machine. Once this is done, you need to add the following environment variables to your project settings.

--- a/_classic/continuous-deployment/deployment-to-digitalocean.md
+++ b/_classic/continuous-deployment/deployment-to-digitalocean.md
@@ -5,6 +5,8 @@ tags:
   - deployment
   - digital ocean
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-digitalocean/
 ---
 ## Different Ways to Deploy
 DigitalOcean offers virtual servers (called Droplets).

--- a/_classic/continuous-deployment/deployment-to-elastic-beanstalk.md
+++ b/_classic/continuous-deployment/deployment-to-elastic-beanstalk.md
@@ -6,6 +6,8 @@ tags:
   - deployment
   - elastic beanstalk
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-elastic-beanstalk/
 ---
 ## Prerequisites
 

--- a/_classic/continuous-deployment/deployment-to-google-app-engine.md
+++ b/_classic/continuous-deployment/deployment-to-google-app-engine.md
@@ -6,6 +6,8 @@ tags:
   - deployment
   - google app engine
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-google-app-engine/
 ---
 You can deploy your [Java]({{ site.baseurl }}{% link _classic/languages-frameworks/java-and-jvm-based-languages.md %}),[Python]({{ site.baseurl }}{% link _classic/languages-frameworks/python.md %}), [NodeJS]({{ site.baseurl }}{% link _classic/languages-frameworks/nodejs.md  %}) , or [Go]({{ site.baseurl }}{% link _classic/languages-frameworks/go.md %}) applications to Google App Engine through Codeship.
 

--- a/_classic/continuous-deployment/deployment-to-heroku.md
+++ b/_classic/continuous-deployment/deployment-to-heroku.md
@@ -6,6 +6,8 @@ tags:
   - deployment
   - heroku
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-to-heroku/
 ---
 Codeship makes makes it easy to deploy your application to Heroku using Codeship's integrated [deployment pipelines]({{ site.baseurl }}{% link _classic/getting-started/deployment-pipelines.md %}).
 

--- a/_classic/continuous-deployment/deployment-with-awscli.md
+++ b/_classic/continuous-deployment/deployment-with-awscli.md
@@ -7,6 +7,8 @@ tags:
   - cli
   - amazon
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-with-awscli/
 ---
 The AWS CLI tool does NOT come pre-installed on Codeship Classic infrastructure's build machines.
 

--- a/_classic/continuous-deployment/deployment-with-capistrano.md
+++ b/_classic/continuous-deployment/deployment-with-capistrano.md
@@ -5,6 +5,8 @@ tags:
   - deployment
   - capistrano
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-with-capistrano/
 ---
 You can deploy any kind of Application with Capistrano. For detailed information about Capistrano check [capistranorb.com](http://capistranorb.com). Don't forget to [include Capistrano](#capistrano-is-not-installed-by-default) in your projects as it's not preinstalled on our build servers.
 

--- a/_classic/continuous-deployment/deployment-with-cloud66.md
+++ b/_classic/continuous-deployment/deployment-with-cloud66.md
@@ -4,6 +4,8 @@ tags:
   - deployment
   - cloud66
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-with-cloud66/
 ---
 Integrating [Cloud 66](http://www.cloud66.com/) with Codeship is as simple as copying and pasting a URL!
 

--- a/_classic/continuous-deployment/deployment-with-custom-scripts.md
+++ b/_classic/continuous-deployment/deployment-with-custom-scripts.md
@@ -6,6 +6,8 @@ tags:
   - custom
   - scripts
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-with-custom-scripts/
 ---
 A custom script deployment is useful if your deployment requires additional or custom commands that are not available with some of Codeship's integrated deployment options.
 

--- a/_classic/continuous-deployment/deployment-with-ftp-sftp-scp.md
+++ b/_classic/continuous-deployment/deployment-with-ftp-sftp-scp.md
@@ -7,6 +7,8 @@ tags:
   - scp
   - rsync
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/deployment-with-ftp-sftp-scp/
 ---
 We generally advise to use any SSH based tools like SFTP or SCP for deployment and only use FTP if not possible otherwise.
 

--- a/_classic/continuous-deployment/push-to-remote-repository.md
+++ b/_classic/continuous-deployment/push-to-remote-repository.md
@@ -6,6 +6,8 @@ tags:
   - git
   - push
 category: Continuous Deployment
+redirect_from:
+  - /continuous-deployment/push-to-remote-repository/
 ---
 
 If you want to deploy your application by doing a `git push` to a remote repository please follow these steps:

--- a/_classic/continuous-integration/browser-testing.md
+++ b/_classic/continuous-integration/browser-testing.md
@@ -5,6 +5,8 @@ tags:
   - testing
   - continuous integration
 category: Continuous Integration
+redirect_from:
+  - /continuous-integration/browser-testing/
 ---
 ## Firefox
 Firefox 35 is installed and available in the PATH.

--- a/_classic/continuous-integration/git-submodules.md
+++ b/_classic/continuous-integration/git-submodules.md
@@ -5,6 +5,8 @@ tags:
   - git
   - submodules
 category: Continuous Integration
+redirect_from:
+  - /continuous-integration/git-submodules/
 ---
 
 If your repository includes a `.gitmodules` file Codeship will automatically initialize and update the configured submodules. To do this, we run the following command after cloning your repository.

--- a/_classic/continuous-integration/keep-build-artifacts.md
+++ b/_classic/continuous-integration/keep-build-artifacts.md
@@ -5,6 +5,8 @@ tags:
   - faq
   - artifacts
 category: Continuous Integration
+redirect_from:
+  - /continuous-integration/keep-build-artifacts/
 ---
 
 For security reasons Codeship doesn't keep any artifacts from your builds besides the build log shown on the website. If you want to keep artifacts, you need to push them to a remote server during your builds.

--- a/_classic/continuous-integration/run-a-command-in-the-background.md
+++ b/_classic/continuous-integration/run-a-command-in-the-background.md
@@ -5,6 +5,8 @@ tags:
   - testing
   - faq
 category: Continuous Integration
+redirect_from:
+  - /continuous-integration/run-a-command-in-the-background/
 ---
 
 If you need to run a process in the background during your builds (e.g. to run a service not available by default, or to run a development server provided by your application framework) you can use the following templates to do so.

--- a/_classic/continuous-integration/using-subdomains.md
+++ b/_classic/continuous-integration/using-subdomains.md
@@ -8,6 +8,8 @@ tags:
   - xip.io
   - lvh.me
 category: Continuous Integration
+redirect_from:
+  - /continuous-integration/using-subdomains/
 ---
 
 Sometimes you need to access your application at a specific URL during the build.

--- a/_classic/getting-started/api.md
+++ b/_classic/getting-started/api.md
@@ -5,6 +5,8 @@ tags:
   - api
   - integrations
 category: Getting Started
+redirect_from:
+  - /integrations/api/
 ---
 
 <div class="info-block">

--- a/_classic/getting-started/cassandra.md
+++ b/_classic/getting-started/cassandra.md
@@ -6,6 +6,8 @@ tags:
   - databases
   - cassandra
 category: Getting Started
+redirect_from:
+  - /databases/cassandra/
 ---
 
 The latest version from the `2.0.x` release of [Apache Cassandra](http://cassandra.apache.org/) is installed on the build VMs, but not running by default.

--- a/_classic/getting-started/code-climate.md
+++ b/_classic/getting-started/code-climate.md
@@ -5,6 +5,8 @@ tags:
   - analytics
   - integrations
 category: Getting Started
+redirect_from:
+  - /analytics/code-climate/
 ---
 There is no specific setup necessary to use Code Climate on Codeship.
 You can follow the [Code Climate docs](http://docs.codeclimate.com/article/219-setting-up-test-coverage)

--- a/_classic/getting-started/coveralls.md
+++ b/_classic/getting-started/coveralls.md
@@ -5,6 +5,8 @@ tags:
   - analytics
   - integrations
 category: Getting Started
+redirect_from:
+  - /analytics/coveralls/
 ---
 ## Coveralls Discount Code
 

--- a/_classic/getting-started/deployment-pipelines.md
+++ b/_classic/getting-started/deployment-pipelines.md
@@ -4,6 +4,8 @@ layout: page
 tags:
   - deployment
 category: Getting Started
+redirect_from:
+  - /continuous-deployment/deployment-pipelines/
 ---
 On Codeship, you are able to define **deployment pipelines**. A deployment pipeline is bound to a branch. Every time a build runs for this branch, it kicks off your deployment pipeline.
 

--- a/_classic/getting-started/elasticsearch.md
+++ b/_classic/getting-started/elasticsearch.md
@@ -5,6 +5,8 @@ tags:
   - services
   - elasticsearch
 category: Getting Started
+redirect_from:
+  - /services/elasticsearch/
 ---
 Elasticsearch **1.2.2** is installed on the default port and doesn't require any credentials. However, it is not running by default. To use the Elasticsearch during your builds, start the service via the following command:
 

--- a/_classic/getting-started/ignore-command-on-branch.md
+++ b/_classic/getting-started/ignore-command-on-branch.md
@@ -6,6 +6,8 @@ tags:
   - commands
   - branch
 category: Getting Started
+redirect_from:
+  - /faq/ignore-command-on-branch/
 ---
 ## Ignore command on a branch
 

--- a/_classic/getting-started/memcached.md
+++ b/_classic/getting-started/memcached.md
@@ -5,5 +5,7 @@ tags:
   - services
   - memcached
 category: Getting Started
+redirect_from:
+  - /services/memcached/
 ---
 Memcached **1.4.14** runs on the default port and doesn't require any credentials.

--- a/_classic/getting-started/mongodb.md
+++ b/_classic/getting-started/mongodb.md
@@ -6,6 +6,8 @@ tags:
   - databases
   - mongodb
 category: Getting Started
+redirect_from:
+  - /databases/mongodb/
 ---
 MongoDB **2.6.4** runs on the default port and doesn't require any credentials.
 

--- a/_classic/getting-started/mysql.md
+++ b/_classic/getting-started/mysql.md
@@ -6,6 +6,8 @@ tags:
   - databases
   - mysql
 category: Getting Started
+redirect_from:
+  - /databases/mysql/
 ---
 MySQL **5.6** runs on the default port and the credentials are stored in the `MYSQL_USER` and `MYSQL_PASSWORD` environment variables.
 

--- a/_classic/getting-started/parallelci.md
+++ b/_classic/getting-started/parallelci.md
@@ -7,6 +7,8 @@ tags:
 - parallelci
 - parallelism
 category: Getting Started
+redirect_from:
+  - /continuous-integration/parallelci/
 ---
 
 **ParallelCI** allows you to split your test commands across multiple build VMs to speed up your build time. See the [ParallelCI feature page](http://codeship.com/features/parallelci) to check out how this helped users improve their build times tremendously.

--- a/_classic/getting-started/postgresql.md
+++ b/_classic/getting-started/postgresql.md
@@ -6,6 +6,8 @@ tags:
   - databases
   - postgresql
 category: Getting Started
+redirect_from:
+  - /databases/postgresql/
 ---
 * include a table of contents
 {:toc}

--- a/_classic/getting-started/rabbitmq.md
+++ b/_classic/getting-started/rabbitmq.md
@@ -6,6 +6,8 @@ tags:
   - queues
   - rabbitmq
 category: Getting Started
+redirect_from:
+  - /queues/rabbitmq/
 ---
 RabbitMQ `3.2.4` runs on the default port and doesn't require any credentials.
 

--- a/_classic/getting-started/redis.md
+++ b/_classic/getting-started/redis.md
@@ -6,5 +6,7 @@ tags:
   - queues
   - redis
 category: Getting Started
+redirect_from:
+  - /queues/redis/
 ---
 Redis `2.8.4` runs on the default port and doesn't require any credentials.

--- a/_classic/getting-started/rethinkdb.md
+++ b/_classic/getting-started/rethinkdb.md
@@ -6,6 +6,8 @@ tags:
   - databases
   - rethinkdb
 category: Getting Started
+redirect_from:
+  - /databases/rethinkdb/
 ---
 
 RethinkDB is installed on our test VMs but not running by default. To use the RethinkDB during your builds, start the service via the following command:

--- a/_classic/getting-started/root-level-access.md
+++ b/_classic/getting-started/root-level-access.md
@@ -6,6 +6,8 @@ tags:
   - sudo
   - packages
 category: Getting Started
+redirect_from:
+  - /faq/root-level-access/
 ---
 
 Codeship does not allow root level access (i.e. commands run via `sudo`) for security reasons. If you are looking to install a dependency that's not available via a language specific package manager (e.g. `gem`, `pip`, `npm` or a similar tool), please contact [support@codeship.com](mailto:support@codeship.com) or send us a message using our in-app messenger.

--- a/_classic/getting-started/run-command-if-other-fails.md
+++ b/_classic/getting-started/run-command-if-other-fails.md
@@ -6,6 +6,8 @@ tags:
   - build error
   - commands
 category: Getting Started
+redirect_from:
+  - /faq/run-command-if-other-fails/
 ---
 To run another command if an earlier one fails you can use the following bash syntax
 

--- a/_classic/getting-started/set-environment-variables.md
+++ b/_classic/getting-started/set-environment-variables.md
@@ -4,6 +4,8 @@ weight: 96
 tags:
   - testing
 category: Getting Started
+redirect_from:
+  - /continuous-integration/set-environment-variables/
 ---
 If you set environment variables, they will be available for the whole build. You can set your environment variables in two different ways:
 

--- a/_classic/getting-started/skipping-builds.md
+++ b/_classic/getting-started/skipping-builds.md
@@ -6,6 +6,8 @@ tags:
   - faq
   - builds
 category: Getting Started
+redirect_from:
+  - /continuous-integration/skipping-builds/
 ---
 You can add either of the following skip directives to the commit message of the last commit before you push and that push will be ignored:
 

--- a/_classic/getting-started/ssh-access.md
+++ b/_classic/getting-started/ssh-access.md
@@ -7,6 +7,8 @@ tags:
   - key
   - debug
 category: Getting Started
+redirect_from:
+  - /continuous-integration/ssh-access/
 ---
 You are able to activate build debugging at the bottom of the build detail view for projects running on the classic infrastructure. The SSH debugging session only works for branches still available in your repository.
 

--- a/_classic/getting-started/webhooks.md
+++ b/_classic/getting-started/webhooks.md
@@ -5,6 +5,8 @@ tags:
   - webhooks
   - integrations
 category: Getting Started
+redirect_from:
+  - /integrations/webhooks/
 ---
 ## Setup
 

--- a/_classic/getting-started/wildcard-deployment-pipelines.md
+++ b/_classic/getting-started/wildcard-deployment-pipelines.md
@@ -5,6 +5,8 @@ tags:
   - deployment
   - wildcard
 category: Getting Started
+redirect_from:
+  - /continuous-deployment/wildcard-deployment-pipelines/
 ---
 
 Get more flexible deployment workflows with wildcard deployment pipelines that trigger if a branch starts with a certain prefix. Use one deployment configuration for multiple branches and automatically deploy your feature, release, QA, etc. branches to the corresponding environments.

--- a/_classic/languages-frameworks/dart.md
+++ b/_classic/languages-frameworks/dart.md
@@ -4,6 +4,8 @@ tags:
   - dart
   - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/dart/
 ---
 `$DART_SDK` is available in the Environment and included in the PATH. The installed version of the Dart SDK is `1.5.1`
 

--- a/_classic/languages-frameworks/go.md
+++ b/_classic/languages-frameworks/go.md
@@ -4,6 +4,8 @@ tags:
 - go
 - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/go/
 ---
 We set the `GOPATH` to `${HOME}` and checkout your code into
 

--- a/_classic/languages-frameworks/java-and-jvm-based-languages.md
+++ b/_classic/languages-frameworks/java-and-jvm-based-languages.md
@@ -5,6 +5,8 @@ tags:
   - scala
   - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/java-and-jvm-based-languages/
 ---
 
 ## JDKs

--- a/_classic/languages-frameworks/nodejs.md
+++ b/_classic/languages-frameworks/nodejs.md
@@ -6,6 +6,8 @@ tags:
   - iojs
   - framework
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/nodejs/
 ---
 
 * include a table of contents

--- a/_classic/languages-frameworks/php.md
+++ b/_classic/languages-frameworks/php.md
@@ -5,6 +5,8 @@ tags:
   - php
   - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/php/
 ---
 * include a table of contents
 {:toc}

--- a/_classic/languages-frameworks/python.md
+++ b/_classic/languages-frameworks/python.md
@@ -5,6 +5,8 @@ tags:
   - python
   - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/python/
 ---
 We use **virtualenv** to manage python environments for you. We currently support Python `2.7.6`. Version `3.4.0` of Python is installed as well and available via the `python3` binary.
 

--- a/_classic/languages-frameworks/ruby.md
+++ b/_classic/languages-frameworks/ruby.md
@@ -5,6 +5,8 @@ tags:
   - ruby
   - languages
 category: Languages &amp; Frameworks
+redirect_from:
+  - /languages/ruby/
 ---
 We use RVM to manage different Ruby versions. We set <strong>{% default_ruby_version %}</strong> as the default version. Currently we do not load the Ruby version from your Gemfile. You can always change the Ruby version by running:
 

--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,7 @@ gems:
   - jekyll-coffeescript
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-redirect-from
 collections:
   general:
     title: General

--- a/_docker/continuous-deployment/aws.md
+++ b/_docker/continuous-deployment/aws.md
@@ -6,6 +6,8 @@ tags:
   - aws
   - docker
 category: Continuous Deployment
+redirect_from:
+  - /docker-integration/aws/
 ---
 
 To make it easy for you to deploy your application to AWS we've built a container that has the AWSCLI installed. We will set up a simple example showing you how to configure any deployment to AWS.

--- a/_docker/continuous-deployment/google-cloud.md
+++ b/_docker/continuous-deployment/google-cloud.md
@@ -6,6 +6,8 @@ tags:
   - heroku
   - docker
 category: Continuous Deployment
+redirect_from:
+  - /docker-integration/google-cloud/
 ---
 
 In this article we'll walk you through using our [Google deployment docker container](https://github.com/codeship-library/google-cloud-deployment), set up authentication and interact with resources in the Google Cloud. The Google Cloud SDK is installed supporting all Google Cloud services, including App Engine (in preview), Google Compute Engine and Google Container Engine.

--- a/_docker/continuous-deployment/heroku.md
+++ b/_docker/continuous-deployment/heroku.md
@@ -6,6 +6,8 @@ tags:
   - heroku
   - docker
 category: Continuous Deployment
+redirect_from:
+  - /docker-integration/heroku/
 ---
 
 To make it easy for you to deploy your application to Heroku we've built a container that has the Heroku Toolbelt and additional scripts installed. We will set up a simple example showing you how to configure the deployment.

--- a/_docker/continuous-integration/browser-testing.md
+++ b/_docker/continuous-integration/browser-testing.md
@@ -8,6 +8,8 @@ tags:
   - tools
   - browser
 category: Continuous Integration
+redirect_from:
+  - /docker/browser-testing/
 ---
 
 Running on our Docker based infrastructure you have many different options to set up browser testing. Following we will describe how you can install different browsers. Please check the language documentation for specifics on how to test with your browser in a specific language.

--- a/_docker/getting-started/caching.md
+++ b/_docker/getting-started/caching.md
@@ -6,6 +6,8 @@ tags:
   - docker
   - tutorial
 category: Getting Started
+redirect_from:
+  - /docker/caching/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/cli.md
+++ b/_docker/getting-started/cli.md
@@ -8,11 +8,13 @@ tags:
   - commands
   - running locally
 category: Getting Started
+redirect_from:
+  - /docker/cli/
+  - /jet/
 ---
 
 <div class="info-block">
 These commands are applicable if you want to run the Codeship local development CLI, `jet` binary, locally. Some of these options are only available locally and are unavailable in the hosted Codeship environment. If you haven't already, [you will need to install Jet.]({{ site.baseurl }}{% link _docker/getting-started/installation.md %})
-
 </div>
 
 * include a table of contents

--- a/_docker/getting-started/codeship-configuration.md
+++ b/_docker/getting-started/codeship-configuration.md
@@ -10,6 +10,8 @@ tags:
   - project configuration
   - tutorial
 category: Getting Started
+redirect_from:
+  - /docker/codeship-configuration/
 ---
 
 <div class="info-block">

--- a/_docker/getting-started/community-images.md
+++ b/_docker/getting-started/community-images.md
@@ -7,6 +7,8 @@ tags:
   - jet
   - images
 category: Getting Started
+redirect_from:
+  - /docker/community-images/
 ---
 
 Codeship community members can develop and maintain base images that they may want to share with other Docker users.

--- a/_docker/getting-started/custom-notifications.md
+++ b/_docker/getting-started/custom-notifications.md
@@ -8,6 +8,8 @@ tags:
   - push
   - registry
 category: Getting Started
+redirect_from:
+  - /docker/custom-notifications/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/docker-pull.md
+++ b/_docker/getting-started/docker-pull.md
@@ -8,6 +8,8 @@ tags:
   - pull
   - registry
 category: Getting Started
+redirect_from:
+  - /docker/docker-pull/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/docker-push.md
+++ b/_docker/getting-started/docker-push.md
@@ -8,6 +8,8 @@ tags:
   - push
   - registry
 category: Getting Started
+redirect_from:
+  - /docker/docker-push/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/docker-volumes.md
+++ b/_docker/getting-started/docker-volumes.md
@@ -6,6 +6,8 @@ tags:
   - docker
   - tutorial
 category: Getting Started
+redirect_from:
+  - /docker/docker-volumes/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/dockercfg-services.md
+++ b/_docker/getting-started/dockercfg-services.md
@@ -8,6 +8,8 @@ tags:
   - push
   - registry
 category: Getting Started
+redirect_from:
+  - /docker/dockercfg-services/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/encryption.md
+++ b/_docker/getting-started/encryption.md
@@ -7,6 +7,8 @@ tags:
   - tutorial
   - encryption
 category: Getting Started
+redirect_from:
+  - /docker/encryption/
 ---
 
 If you need to make private information available to your build, you can save this information encrypted in your repository. This is most often needed to either make credentials used during deployment available or store credentials for a Docker registry. See e.g our [Docker Push]({{ site.baseurl }}{% link _docker/getting-started/docker-push.md %}) tutorial for a practical example.

--- a/_docker/getting-started/getting-started-part-five.md
+++ b/_docker/getting-started/getting-started-part-five.md
@@ -8,8 +8,10 @@ tags:
   - introduction
   - getting started
   - tutorial
-  - getting started jet  
+  - getting started jet
 category: Getting Started
+redirect_from:
+  - /docker-guide/getting-started-part-five/
 ---
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via

--- a/_docker/getting-started/getting-started-part-four.md
+++ b/_docker/getting-started/getting-started-part-four.md
@@ -8,8 +8,10 @@ tags:
   - introduction
   - getting started
   - tutorial
-  - getting started jet  
+  - getting started jet
 category: Getting Started
+redirect_from:
+  - /docker-guide/getting-started-part-four/
 ---
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via

--- a/_docker/getting-started/getting-started-part-three.md
+++ b/_docker/getting-started/getting-started-part-three.md
@@ -8,8 +8,10 @@ tags:
   - introduction
   - getting started
   - tutorial
-  - getting started jet  
+  - getting started jet
 category: Getting Started
+redirect_from:
+  - /docker-guide/getting-started-part-three/
 ---
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via

--- a/_docker/getting-started/getting-started-part-two.md
+++ b/_docker/getting-started/getting-started-part-two.md
@@ -8,8 +8,10 @@ tags:
   - introduction
   - getting started
   - tutorial
-  - getting started jet  
+  - getting started jet
 category: Getting Started
+redirect_from:
+  - /docker-guide/getting-started-part-two/
 ---
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via

--- a/_docker/getting-started/getting-started.md
+++ b/_docker/getting-started/getting-started.md
@@ -10,6 +10,8 @@ tags:
   - tutorial
   - getting started jet
 category: Getting Started
+redirect_from:
+  - /docker-guide/getting-started/
 ---
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via

--- a/_docker/getting-started/image-push-fails.md
+++ b/_docker/getting-started/image-push-fails.md
@@ -5,8 +5,9 @@ tags:
   - faq
   - builds
   - docker
-categories:
 category: Getting Started
+redirect_from:
+  - /docker/image-push-fails/
 ---
 
 The **image** in `codeship-services.yml` has to match the **image_name** in `codeship-steps.yml`, like in the following example:

--- a/_docker/getting-started/installation.md
+++ b/_docker/getting-started/installation.md
@@ -9,6 +9,8 @@ tags:
   - installation
   - running locally
 category: Getting Started
+redirect_from:
+  - /docker/installation/
 ---
 
 <div class="info-block">

--- a/_docker/getting-started/release-notes.md
+++ b/_docker/getting-started/release-notes.md
@@ -7,6 +7,8 @@ tags:
   - jet
   - release notes
 category: Getting Started
+redirect_from:
+  - /docker/release-notes/
 ---
 
 <div class="info-block">

--- a/_docker/getting-started/services-and-databases.md
+++ b/_docker/getting-started/services-and-databases.md
@@ -9,6 +9,8 @@ tags:
   - services
   - databases
 category: Getting Started
+redirect_from:
+  - /docker/services-and-databases/
 ---
 
 Through Docker we support many different databases and services you can use for your build. By adding them to your `codeship-services.yml` file you have a lot of control on how to set up your build environment.

--- a/_docker/getting-started/services.md
+++ b/_docker/getting-started/services.md
@@ -8,6 +8,8 @@ tags:
   - configuration
   - services
 category: Getting Started
+redirect_from:
+  - /docker/services/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/skipping-builds.md
+++ b/_docker/getting-started/skipping-builds.md
@@ -8,6 +8,8 @@ tags:
   - builds
   - testing
 category: Getting Started
+redirect_from:
+  - /docker/skipping-builds/
 ---
 You can add either of the following skip directives to the commit message of the last commit before you push and that push will be ignored:
 

--- a/_docker/getting-started/ssh-key-authentication.md
+++ b/_docker/getting-started/ssh-key-authentication.md
@@ -8,6 +8,8 @@ tags:
   - ssh key
   - encryption
 category: Getting Started
+redirect_from:
+  - /docker/ssh-key-authentication/
 ---
 
 * include a table of contents

--- a/_docker/getting-started/steps.md
+++ b/_docker/getting-started/steps.md
@@ -8,6 +8,8 @@ tags:
   - configuration
   - steps
 category: Getting Started
+redirect_from:
+  - /docker/steps/
 ---
 
 * include a table of contents

--- a/_docker/languages-frameworks/go.md
+++ b/_docker/languages-frameworks/go.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/go/
 ---
 In this article you will learn about setting up a Go based project on our Docker infrastructure.
 

--- a/_docker/languages-frameworks/java.md
+++ b/_docker/languages-frameworks/java.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/java/
 ---
 In this article you will learn about setting up a Java based project on our Docker infrastructure. We will use Maven and Gradle for our build configuration, but the same concept applies for any other Java based language or tool.
 

--- a/_docker/languages-frameworks/nodejs.md
+++ b/_docker/languages-frameworks/nodejs.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/nodejs/
 ---
 In this article you will learn about setting up a Node.js based project on our Docker infrastructure.
 

--- a/_docker/languages-frameworks/php.md
+++ b/_docker/languages-frameworks/php.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/php/
 ---
 In this article you will learn about setting up a PHP based project and runnning your phpunit tests. This setup will allow you to run any other PHP based tool as well.
 

--- a/_docker/languages-frameworks/python.md
+++ b/_docker/languages-frameworks/python.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/python/
 ---
 In this article you will learn about setting up a Python based project on our Docker infrastructure. We will use [nosetest](https://nose.readthedocs.org/en/latest/) and [py.test](http://pytest.org/latest/) for setting up the build, but the same works for any other test framework as well.
 

--- a/_docker/languages-frameworks/ruby.md
+++ b/_docker/languages-frameworks/ruby.md
@@ -6,6 +6,8 @@ tags:
   - languages
   - docker
 category: Languages &amp; Frameworks
+redirect_from:
+  - /docker-integration/ruby/
 ---
 In this article you will learn about setting up a Ruby based project, including Rails projects, on our Docker infrastructure. We will set up testing with RSpec and Cucumber, but the same applies to any other Ruby testing framework.
 

--- a/_general/about/codeship-badge.md
+++ b/_general/about/codeship-badge.md
@@ -5,6 +5,8 @@ tags:
   - faq
   - badge
 category: About
+redirect_from:
+  - /faq/codeship-badge/
 ---
 If you want to add a badge showing your last builds status to your ReadMe, you can find the code in the **Notification** settings of your project.
 

--- a/_general/about/getting_started_with_ci.md
+++ b/_general/about/getting_started_with_ci.md
@@ -5,6 +5,8 @@ tags:
   - faq
   - getting started
 category: About
+redirect_from:
+  - /faq/getting_started_with_ci/
 ---
 * [Introduction to Continuous Integration by Martin Fowler](http://martinfowler.com/articles/continuousIntegration.html)
 * [Why Continuous Deployment by Eric Ries](http://www.startuplessonslearned.com/2009/06/why-continuous-deployment.html)

--- a/_general/about/other-scm.md
+++ b/_general/about/other-scm.md
@@ -6,6 +6,8 @@ tags:
   - scm
   - svn
 category: About
+redirect_from:
+  - /faq/other-scm/
 ---
 Codeship currently only supports [GitHub](https://github.com/) and [BitBucket](https://bitbucket.org/) based repositories. While we do have plans to integrate with other providers in the future we don't have anything concrete planned at the moment.
 

--- a/_general/about/vm-and-infrastructure.md
+++ b/_general/about/vm-and-infrastructure.md
@@ -5,6 +5,9 @@ tags:
   - security
   - infrastructure
 category: About
+redirect_from:
+  - /security/vm-and-Infrastructure/
+  - /security/vm-and-infrastructure/
 ---
 ## OS & Virtualization
 We use **Ubuntu 14.04 (Trusty Tahr)** on our test machines. To virtualize the test machines we use **Linux Containers**.

--- a/_general/about/vm-and-infrastructure.md
+++ b/_general/about/vm-and-infrastructure.md
@@ -6,7 +6,6 @@ tags:
   - infrastructure
 category: About
 redirect_from:
-  - /security/vm-and-Infrastructure/
   - /security/vm-and-infrastructure/
 ---
 ## OS & Virtualization

--- a/_general/account/configure-your-avatar.md
+++ b/_general/account/configure-your-avatar.md
@@ -6,6 +6,8 @@ tags:
   - avatar
   - gravatar
 category: Account
+redirect_from:
+  - /faq/configure-your-avatar/
 ---
 
 Git identifies people by their e-mail and uses your Gravatar settings for your profile picture. If you have not set up Gravatar yet and want to change the avatar shown on Codeship and in your commit messages, please head over to [Gravatar.com](http://www.gravatar.com/) and setup an avatar for both the email address you configured in your Codeship [Account Settings](https://codeship.com/user/edit) as well as for any email addresses you use in your git configuration.

--- a/_general/account/github-3rd-party-restrictions.md
+++ b/_general/account/github-3rd-party-restrictions.md
@@ -7,6 +7,8 @@ tags:
   - scm
   - 3rd party restrictions
 category: Account
+redirect_from:
+  - /troubleshooting/github-3rd-party-restrictions/
 ---
 
 If the repositories for a GitHub organization don't show up on Codeship, please head over to the settings for the [Codeship application on GitHub](https://github.com/settings/connections/applications/457423eb34859f8eb490) and in the section labeled **Organization access** either

--- a/_general/account/notifications.md
+++ b/_general/account/notifications.md
@@ -5,6 +5,8 @@ tags:
   - administration
   - notifications
 category: Account
+redirect_from:
+  - /administration/notifications/
 ---
 ## Where can I configure Notifications
 Click the project menu on the top navigation and click the settings wheel to get to your project settings. There, click the **Notifications** link.

--- a/_general/account/organizations.md
+++ b/_general/account/organizations.md
@@ -7,6 +7,8 @@ tags:
   - organizations
   - team management
 category: Account
+redirect_from:
+  - /administration/organizations/
 ---
 
 Organizations simplify and enhance team management as well as subscription management for (larger) teams on Codeship.

--- a/_general/projects/access-to-other-repositories-fails-during-build.md
+++ b/_general/projects/access-to-other-repositories-fails-during-build.md
@@ -9,6 +9,8 @@ tags:
   - bitbucket
   - private repository
 category: Projects
+redirect_from:
+  - /faq/access-to-other-repositories-fails-during-build/
 ---
 Some builds require access to other private repositories for example to use as a dependency. Codeship creates a SSH key pair for each project when you first configure it. You can view the public key on the _General_ page of your project settings and it gets automatically added as a deploy key to your GitHub or BitBucket repository.
 

--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -7,6 +7,8 @@ tags:
   - github
   - bitbucket
 category: Projects
+redirect_from:
+  - /troubleshooting/builds-are-not-triggered/
 ---
 
 Builds on Codeship are triggered via a webhook from GitHub or BitBucket. We add this hook to your repository when you configure the project on Codeship, but sometimes those settings get out of sync.

--- a/_general/projects/check_url-fails-for-heroku-deployment.md
+++ b/_general/projects/check_url-fails-for-heroku-deployment.md
@@ -6,6 +6,8 @@ tags:
   - build error
   - heroku
 category: Projects
+redirect_from:
+  - /faq/check_url-fails-for-heroku-deployment/
 ---
 After each deployment we check if your app is up. Therefore we call (`wget`) either the default `*.herokuapps.com` URL or the URL you specified here.
 

--- a/_general/projects/could-not-find-gemname-in-any-of-the-sources.md
+++ b/_general/projects/could-not-find-gemname-in-any-of-the-sources.md
@@ -6,6 +6,8 @@ tags:
   - build error
   - ruby
 category: Projects
+redirect_from:
+  - /faq/could-not-find-gemname-in-any-of-the-sources/
 ---
 Sometimes you might see errors like the following:
 

--- a/_general/projects/delete-a-project.md
+++ b/_general/projects/delete-a-project.md
@@ -5,6 +5,8 @@ tags:
   - administration
   - project
 category: Projects
+redirect_from:
+  - /administration/delete-a-project/
 ---
 If you are the project owner you can delete your project by going to
 

--- a/_general/projects/enabling-access-to-servers.md
+++ b/_general/projects/enabling-access-to-servers.md
@@ -8,6 +8,8 @@ tags:
   - ip addresses
   - iam
 category: Projects
+redirect_from:
+  - /faq/enabling-access-to-servers
 ---
 ## IP Addresses
 

--- a/_general/projects/limit_builds.md
+++ b/_general/projects/limit_builds.md
@@ -5,6 +5,8 @@ tags:
   - faq
   - builds
 category: Projects
+redirect_from:
+  - /faq/limit_builds/
 ---
 We don’t have a feature to limit which branches can be built.
 

--- a/_general/projects/no-such-file-or-directory-config-yourconfigyml.md
+++ b/_general/projects/no-such-file-or-directory-config-yourconfigyml.md
@@ -5,6 +5,8 @@ tags:
   - troubleshooting
   - build error
 category: Projects
+redirect_from:
+  - /troubleshooting/no-such-file-or-directory-config-yourconfigyml/
 ---
 If it's a configuration file which you ignored in your repository, create a `your_config.yml.example` with data that works for your tests an add it to your repository. Then add the following command to your **setup commands** so the YAML file is properly set up.
 

--- a/_general/projects/push-to-remote-repositories.md
+++ b/_general/projects/push-to-remote-repositories.md
@@ -10,6 +10,8 @@ tags:
   - push
   - git
 category: Projects
+redirect_from:
+  - /troubleshooting/push-to-remote-repositories/
 ---
 If you want to push to a remote git repository during your deployment steps on Codeship, and the build fails with an error message such as the following:
 

--- a/_general/projects/testing-prs-from-forked-repositories.md
+++ b/_general/projects/testing-prs-from-forked-repositories.md
@@ -9,6 +9,8 @@ tags:
   - github
   - bitbucket
 category: Projects
+redirect_from:
+  - /faq/testing-prs-from-forked-repositories/
 ---
 
 Codeship does not support testing pull requests from forked repositories at the moment. You'd need to configure the forked repository separately on Codeship or push the branch to the already configured repository instead.

--- a/_general/projects/transfer-project-to-new-owner.md
+++ b/_general/projects/transfer-project-to-new-owner.md
@@ -5,6 +5,8 @@ tags:
   - administration
   - project
 category: Projects
+redirect_from:
+  - /administration/transfer-project-to-new-owner/
 ---
 You can transfer your project to another account by navigating to:
 

--- a/_general/projects/where-can-i-find-the-ssh-public-key-for-my-project.md
+++ b/_general/projects/where-can-i-find-the-ssh-public-key-for-my-project.md
@@ -6,6 +6,8 @@ tags:
   - ssh key
   - faq
 category: Projects
+redirect_from:
+  - /continuous-integration/where-can-i-find-the-ssh-public-key-for-my-project/
 ---
 Open the project navigation on top of the page. Click on the settings icon next to the respective project.
 

--- a/classic/index.md
+++ b/classic/index.md
@@ -1,6 +1,9 @@
 ---
 layout: page
 collection: classic
+redirect_from:
+  - /continuous-integration/welcome-classic-infrastructure/
+  - /classic/getting-started/welcome-classic-infrastructure/
 ---
 
 Welcome to Codeship's Classic Infrastructure with pre-configured VMs where we take care of the infrastructure for you. We host the environment, you provide the code.

--- a/docker/index.md
+++ b/docker/index.md
@@ -1,6 +1,8 @@
 ---
 layout: page
 collection: docker
+redirect_from:
+  - /docker/introduction/
 ---
 
 Welcome to Codeship's Docker Infrastructure, the new way to run your tests on Codeship. Enjoy full customizability. Easily mirror your Development, Test and Production Environments with full parity. The underlying build infrastructure, based on Docker, allows for customized definition of the running environment.


### PR DESCRIPTION
Add the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) gem, which allows us to redirect from old article URLs to new ones via a HTTP-REFRESH meta tag.

This PR includes redirects for all crawl errors found in Google Search Console as well as the redirects already configured via `_website.json`.

A staging build is available at https://documentation.codeship.com/staging/jekyll-redirects/. See https://documentation.codeship.com/staging/jekyll-redirects/administration/delete-a-project/ for an example article that gets redirected.