### PR TITLE
S3 Redirects

### DIFF
--- a/bin/s3.sh
+++ b/bin/s3.sh
@@ -26,7 +26,7 @@ case "$action" in
 		;;
 	'configure_redirects')
 		if [ "${CI_BRANCH}" = "master" ]; then
-			cd /site/_site || exit 1
+			cd /site/master/ || exit 1
 		else
 			cd /site/ || exit 1
 		fi

--- a/bin/s3.sh
+++ b/bin/s3.sh
@@ -24,6 +24,26 @@ case "$action" in
 		config_file=${1:?'You need to pass an action!'} && shift
 		aws s3api put-bucket-lifecycle --bucket "${AWS_S3_BUCKET}" --lifecycle-configuration "file://${config_file}"
 		;;
+	'configure_redirects')
+		if [ "${CI_BRANCH}" = "master" ]; then
+			cd /site/_site || exit 1
+		else
+			cd /site/ || exit 1
+		fi
+		for file in $(grep -rl -E '<meta\s+http-equiv="refresh"\s+content="0;\s+url=.*">' *); do
+			src="${file}"
+			tgt=$(grep -o -E '<meta\s+http-equiv="refresh"\s+content="0;\s+url=.*">' "${file}" | sed -E 's/<meta http-equiv="refresh" content="0; url=(.*)">/\1/g')
+			log "Redirect ${src} to ${tgt}"
+			aws s3api put-object \
+			  --bucket "${AWS_S3_BUCKET}" \
+			  --key "${src}" \
+			  --website-redirect-location "${tgt}" \
+			  --acl "public-read" \
+			  --content-type "text/html" \
+			  --body "${file}"
+		done
+		cd - || exit 1
+		;;
 	*)
 		log "Invalid action ${action} :("
 		exit 1

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -31,21 +31,27 @@
   name: deploying
   tag: "^(master|staging/.*|private/.*)$"
   steps:
-    - name: s3_sync
-      service: aws
-      command: sh bin/s3.sh sync
     - type: serial
-      tag: "^master$"
+      name: s3_deployment
       steps:
-        - name: s3_website
+        - name: s3_sync
           service: aws
-          command: sh bin/s3.sh configure_website _website.json
-        - name: s3_lifecycle
+          command: sh bin/s3.sh sync
+        - name: s3_redirects
           service: aws
-          command: sh bin/s3.sh configure_lifecycle _lifecycle.json
-        - name: swiftype
-          service: documentation
-          command: sh bin/swiftype.sh
+          command: sh bin/s3.sh configure_redirects
+        - type: serial
+          tag: "^master$"
+          steps:
+            - name: s3_website
+              service: aws
+              command: sh bin/s3.sh configure_website _website.json
+            - name: s3_lifecycle
+              service: aws
+              command: sh bin/s3.sh configure_lifecycle _lifecycle.json
+            - name: swiftype
+              service: documentation
+              command: sh bin/swiftype.sh
     - type: push
       tag: "^master$"
       name: push_docker_hub


### PR DESCRIPTION
For each of the pages generated by the `jekyll-redirect-from` from gem, create a website redirect as documented on https://aws.amazon.com/blogs/aws/amazon-s3-support-for-website-redirects/

The script ins this PR looks through the generated site searching for the meta refresh tag, gets the target URL and then pushes the same file to AWS S3 with the added `--website-redirect-location` option set to the target URL.

That option will trigger a 301 permanent redirect on CloudFront.

Staging build available at https://app.codeship.com/projects/102044/builds/9dc53ef9-cb78-4707-aed3-84a9c014b811 and deployed to https://documentation.codeship.com/staging/s3-redirects-take1/.

See e.g. https://documentation.codeship.com/staging/s3-redirects-take1/databases/cassandra/  which redirects (via HTTP) to https://documentation.codeship.com/staging/s3-redirects-take1/classic/getting-started/cassandra/