### PR TITLE
Completely remove the RoutingRules

### DIFF
--- a/_website.json
+++ b/_website.json
@@ -4,6 +4,5 @@
   },
   "ErrorDocument": {
     "Key": "404/index.html"
-  },
-  "RoutingRules": []
+  }
 }


### PR DESCRIPTION
The AWS CLI complains about an empty object, so we need to remove it completely.