### PR TITLE
Add documentation for build args to services and encryption pages

### DIFF
--- a/_docker/getting-started/build-arguments.md
+++ b/_docker/getting-started/build-arguments.md
@@ -1,0 +1,23 @@
+---
+title: "Tutorial: Build Arguments"
+layout: page
+weight: 45
+tags:
+  - docker
+  - tutorial
+category: Getting Started
+---
+
+* include a table of contents
+{:toc}
+
+## Overview: Build Arguments
+For each service, you can declare build arguments, which are values available to the image only at build time. For example, if you must pass the image a set of credentials in order to access an asset or repository when the image is being buit, you would pass that value to the image as a build argument.  
+
+## Build Arguments vs. Environment Variables
+
+## Using Basic Build Arguments with Codeship
+
+## Encrypted Build Arguments
+
+

--- a/_docker/getting-started/build-arguments.md
+++ b/_docker/getting-started/build-arguments.md
@@ -12,12 +12,74 @@ category: Getting Started
 {:toc}
 
 ## Overview: Build Arguments
-For each service, you can declare build arguments, which are values available to the image only at build time. For example, if you must pass the image a set of credentials in order to access an asset or repository when the image is being buit, you would pass that value to the image as a build argument.  
+For each service, you can declare [build arguments](https://docs.docker.com/compose/compose-file/#/args), which are values available to the image only at build time. For example, if you must pass the image a set of credentials in order to access an asset or repository when the image is built, you would pass that value to the image as a build argument.  
 
 ## Build Arguments vs. Environment Variables
+During a build on Codeship's Docker platform, there are three ways to pass custom values to your services:
 
-## Using Basic Build Arguments with Codeship
+* Build arguments or encrypted build arguments: available only at image build time
+* ENV variable declared in Dockerfile: available at build time and runtime
+* environment or encrypted environment: available only at runtime
+
+Build arguments are unique in that they are available only at build time. They are not persisted in the image. However, you may assign a build argument to an environment variable during the build process, and that environment variable will be available.
+
+## Using Unencrypted Build Arguments with Codeship
+Declaring build arguments in your services file requires updates in two places: the service's Dockerfile and the `codeship-services.yml` file.
+
+### Dockerfile ARG instruction
+The service's Dockerfile must include the `ARG` [instruction](https://docs.docker.com/engine/reference/builder/#/arg), which declares the name of the argument you will pass at build time. You may also declare a default here.
+
+```bash
+FROM ubuntu:latest
+
+ARG build_env # build_env=test would make test the default value
+
+RUN script-requiring-build-env.sh "$build_env"
+```
+
+### Passing build args in the services file
+Now that the Dockerfile knows to expect an argument, you can pass the argument to the image via the service configuration in `codeship-services.yml`. 
+
+```bash
+app:
+  build:
+    dockerfile_path: Dockerfile
+    args:
+      build_env: staging
+```
+
+When the `app` service is built, the value of `build_env` becomes `staging`. If no value was set, `build_env` would remain `test`. You are not required to declare a default, but you must add an `ARG` instruction to the Dockerfile for each build argument you pass in via `codeship-services.yml`.
+
+Note: YAML boolean values (true, false, yes, no, on, off) must be enclosed in quotes, so that the parser interprets them as strings.
 
 ## Encrypted Build Arguments
+In a lot of cases, the values needed by the image at build time are secrets -- credentials, passwords, and other things that you don't want to check in to source control in plain text. Because of this, Codeship supports encrypted build arguments. You can either encrypt a file containing all of the build arguments you need, or pass them to the service individually.
 
+First, create a file in the root directory - in this case, a file named `build_args`. You will also need to [download the project AES key]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %}) to root directory (and add it to the `.gitignore` file.)
 
+```bash
+GEM_SERVER_TOKEN=XXXXXXXXXXXX
+SECRET_BUILDTIME_PASSWORD=XXXXXXXXXXXX
+```
+
+Once the AES key is in the root directory, run the `jet encrypt` command with an *input* and an *output* filename: `jet encrypt build_args build_args.encrypted` ([Learn more about using Jet]({{ site.baseurl }}{% link _docker/getting-started/installation.md %}))
+
+Pass that file to your service's build directive.
+
+```yaml
+app:
+  build:
+    dockerfile_path: Dockerfile
+    encrypted_args_file: build_args.encrypted
+```
+
+Codeship will decrypt your build arguments and pass them to the image when it is built.
+
+## Impact on Docker Image Caching
+Docker will attempt to reuse layers of your image if there are no changes. Although the values of a build argument are not persisted to the image, they do impact the build cache in a similar way. Refer to Docker's [notes on cache invalidation](https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching) when using build arguments.
+
+## Common Error Messages
+`One or more build-args [XXX] were not consumed`
+
+If you pass a build argument to an image at build time, but do not have a corresponding `ARG` instruction in the Dockerfile, Docker (versions < 1.13) will fail the image build. 
+As of 1.13, unused build args will not fail the build, but will generate a warning message.

--- a/_docker/getting-started/build-arguments.md
+++ b/_docker/getting-started/build-arguments.md
@@ -11,6 +11,10 @@ category: Getting Started
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This feature is in private beta. If you are a Codeship customer with projects running on our Docker infrastructure, contact us at [beta@codeship.com](mailto:beta@codeship.com) to request access to this feature.
+</div>
+
 ## Overview: Build Arguments
 For each service, you can declare [build arguments](https://docs.docker.com/compose/compose-file/#/args), which are values available to the image only at build time. For example, if you must pass the image a set of credentials in order to access an asset or repository when the image is built, you would pass that value to the image as a build argument.  
 
@@ -53,7 +57,7 @@ When the `app` service is built, the value of `build_env` becomes `staging`. If 
 Note: YAML boolean values (true, false, yes, no, on, off) must be enclosed in quotes, so that the parser interprets them as strings.
 
 ## Encrypted Build Arguments
-In a lot of cases, the values needed by the image at build time are secrets -- credentials, passwords, and other things that you don't want to check in to source control in plain text. Because of this, Codeship supports encrypted build arguments. You can either encrypt a file containing all of the build arguments you need, or pass them to the service individually.
+In a lot of cases, the values needed by the image at build time are secrets -- credentials, passwords, and other things that you don't want to check in to source control in plain text. Because of this, Codeship supports encrypted build arguments. You can either encrypt a build argument individually, or encrypt an entire file containing all of the build arguments you need.
 
 First, create a file in the root directory - in this case, a file named `build_args`. You will also need to [download the project AES key]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %}) to root directory (and add it to the `.gitignore` file.)
 
@@ -71,6 +75,15 @@ app:
   build:
     dockerfile_path: Dockerfile
     encrypted_args_file: build_args.encrypted
+```
+
+If your use case is simple enough, you may want to pass in encrypted values directly instead of requiring Codeship to read them from a file. The following syntax is also supported:
+
+```yaml
+app:
+  build:
+    dockerfile_path: Dockerfile
+    encrypted_args: 8rD1P1xO1CwB4L99JBqnvoSOX+1wimf9qwHXATf9foasPtU6Sw==
 ```
 
 Codeship will decrypt your build arguments and pass them to the image when it is built.

--- a/_docker/getting-started/encryption.md
+++ b/_docker/getting-started/encryption.md
@@ -80,6 +80,11 @@ aws:
 
 ## Build Arguments
 
+<div class="info-block">
+Build arguments are in private beta. If you are a Codeship customer with projects running on our Docker infrastructure, contact us at [beta@codeship.com](mailto:beta@codeship.com) to request access to this feature.
+</div>
+
+
 It might be necessary to pass encrypted values to the image at buildtime. A common use case for this is credentials for a repository or asset needed during the image building process, such as accessing a private gem server. In this case, you can encrypt a file of [build arguments](https://docs.docker.com/compose/compose-file/#/args) that will be passed to the image at build time.
 
 Save the file as e.g. `buildargs.env` in your repository. It could contain the following data

--- a/_docker/getting-started/encryption.md
+++ b/_docker/getting-started/encryption.md
@@ -78,6 +78,36 @@ aws:
   encrypted_env_file: deployment.env.encrypted
 ```
 
+## Build Arguments
+
+It might be necessary to pass encrypted values to the image at buildtime. A common use case for this is credentials for a repository or asset needed during the image building process, such as accessing a private gem server. In this case, you can encrypt a file of [build arguments](https://docs.docker.com/compose/compose-file/#/args) that will be passed to the image at build time.
+
+Save the file as e.g. `buildargs.env` in your repository. It could contain the following data
+
+```
+GEM_SERVER_AUTH=XXXXXXXXXXXXXXXXXXXXX
+```
+
+To encrypt this file with the key saved previously you would run the following commands
+
+```bash
+# jet encrypt [--key-path=codeship.aes] plain_file encrypted_file
+jet encrypt buildargs.env buildargs.env.encrypted
+# also add the plain text version to .gitignore
+echo "buildargs.env" >> .gitignore
+```
+
+To load the file during the build adapt your `codeship-services.yml` and reference the encrypted files
+
+```yaml
+app:
+  build:
+     dockerfile: Dockerfile.ci
+     encrypted_args_file: buildargs.env.encrypted
+```
+
+## Decrypting
+
 If you need to decrypt the encrypted file run the following command instead
 
 ```bash

--- a/_docker/getting-started/encryption.md
+++ b/_docker/getting-started/encryption.md
@@ -85,7 +85,8 @@ It might be necessary to pass encrypted values to the image at buildtime. A comm
 Save the file as e.g. `buildargs.env` in your repository. It could contain the following data
 
 ```
-GEM_SERVER_AUTH=XXXXXXXXXXXXXXXXXXXXX
+GEM_SERVER_TOKEN=XXXXXXXXXXXX
+SECRET_BUILDTIME_PASSWORD=XXXXXXXXXXXX
 ```
 
 To encrypt this file with the key saved previously you would run the following commands

--- a/_docker/getting-started/services.md
+++ b/_docker/getting-started/services.md
@@ -59,12 +59,21 @@ app:
 
 * `args`: build arguments passed to the image at build time. [Learn more about build arguments.]({{ site.baseurl }}{% link _docker/getting-started/build-arguments.md %})
 
+* `encrypted_args_file`: an encrypted file of build arguments that are passed to the image at build time. [Learn more about build arguments.]({{ site.baseurl }}{% link _docker/getting-started/build-arguments.md %})
+
+### Image
+Some services are available on the Docker Hub or other registry, and you may want to use those images instead of building your own. To start a service with a Docker image available on a registry, use the `image` key.
+
+```yaml
+database:
+  image: postgres:latest
+```
+
 ### Volumes
 You can use `volumes` in your `codeship-services.yml` file to persist data between containers as well as between steps in your CI/CD process.
 
 An example setup using volumes in your `codeship-services.yml` file would look like this:
 
-```
 ```yaml
 app:
   build:
@@ -105,7 +114,7 @@ app:
   encrypted_env_file: env.encrypted
 ```
 
-The way we encrypt our environment variables is by creating a file in our root directory - in this case, a file named `env` and then [downloading our project AES key.]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %}) to root directory (and adding it to our `.gitignore` file.)
+The way we encrypt our environment variables is by creating a file in our root directory - in this case, a file named `env` and then [downloading our project AES key]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %}) to root directory (and adding it to our `.gitignore` file.)
 
 Once the AES key is in our directory, we can run the `jet encrypt` command with an *input* and an *output* filename: `jet encrypt env env.encrypted` ([Learn more about using Jet]({{ site.baseurl }}{% link _docker/getting-started/installation.md %}))
 
@@ -133,15 +142,14 @@ app:
   cached: true
 ```
 
-There are several specific requirements and considerations when using caching, so it is recommended that you [read our caching documentation.]({{ site.baseurl }}{% link _docker/getting-started/caching.md %}) before enabling caching on your builds.
+There are several specific requirements and considerations when using caching, so it is recommended that you [read our caching documentation]({{ site.baseurl }}{% link _docker/getting-started/caching.md %}) before enabling caching on your builds.
 
 ## Unavailable Features
 The following features available from Docker Compose are not available on Codeship.
 
-* Support for version headings, like `version: '2'`
+* Support for version headers, like `version: '2'`
 * Support for nesting services under a top-level `services` key. Use the Docker Compose V1 format where each service is a top-level key.
-* Support for network configuration
-* Support for build arguments
+* Support for top-level network configuration
 * Support for the following directives
   * `depends_on`
   * `cpu_quota`
@@ -157,12 +165,13 @@ All linking to the host is not allowed. This means the following directives are 
 ## More Resources
 * [Docker Compose](https://docs.docker.com/compose/)
 * [Build Directive In Compose](https://docs.docker.com/compose/compose-file/#build)
-* [Encrypting environment variables.]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %})
+* [Encrypting environment variables and build arguments]({{ site.baseurl }}{% link _docker/getting-started/encryption.md %})
 * [Steps File]({% link _docker/getting-started/steps.md %})
 * [Volumes]({{ site.baseurl }}{% link _docker/getting-started/docker-volumes.md %})
 * [Add_Docker Directive in Compose](https://github.com/codeship/codeship-tool-examples/tree/master/14.add_docker)
 * [Docker-in-Docker](https://registry.hub.docker.com/u/jpetazzo/dind).
 * [Caching]({{ site.baseurl }}{% link _docker/getting-started/caching.md %})
+* [Build Arguments]({{ site.baseurl }}{% link _docker/getting-started/build-arguments.md %})
 
 ## Other Notes
 * `link` containers will be newly created for each step.

--- a/_docker/getting-started/services.md
+++ b/_docker/getting-started/services.md
@@ -36,10 +36,10 @@ Your Services file will require that you have [installed Jet locally]({{ site.ba
 ## Services File Setup & Configuration
 By default, we look for the filename `codeship-services.yml` but a `docker-compose.yml` file that does not include any non-support functionality will also be automatically recognized and used if no `codeship-services.yml` is present. Compose commands that we do not yet fully support will usually be ignored, although occasionally they can also trigger errors.
 
-Your services file is structured identically to a standard [Docker Compose](https://docs.docker.com/compose/) file with the exception of the unavailable features listed in this article.
+Your services file is structured identically to a Version 1 [Docker Compose](https://docs.docker.com/compose/) file with the exception of the unavailable features listed in this article.
 
-### Build Directive
-The basic `build` directive, to build containers and images out of your Dockerfile, is fully supported. You [specify a build](https://docs.docker.com/compose/compose-file/#build) in the same way as is standard with Docker Compose, although you can also use an extended version as needed. You can also mix formats between services, but not for a single service - i.e. you can build some of your services from one or more Dockerfiles while other services simply download existing images from registries.
+### Build
+Use the `build` directive to build your service's image from a Dockerfile. You [specify a build](https://docs.docker.com/compose/compose-file/#build) in the same way as is standard with Docker Compose, although you can also use an extended version as needed. You can also mix `build` and `image` between services, but not for a single service - i.e. you can build some of your services from one or more Dockerfiles while other services simply download existing images from registries.
 
 ```yaml
 app:
@@ -47,8 +47,8 @@ app:
     image: codeship/app
     path: app
     dockerfile_path: Dockerfile
-data:
-  image: busybox
+    args:
+      build_env: production
 ```
 
 * `image` specifies the output image name, as opposed to generating one by default.
@@ -56,6 +56,8 @@ data:
 * `path` sets the build context, essentially defining a custom root directory for any ADD or COPY directives (as well as specifying where to look for the Dockerfile). It's important to note that the _Dockerfile_ is searched for relative to that directory. If you don't specify a custom `path`, it will default to the directory of the services file.
 
 * `dockerfile_path` allows you to specify a specific Dockerfile to use, rather than inheriting one from the build context. It does not, however, change the build context or override the root directory.
+
+* `args`: build arguments passed to the image at build time. [Learn more about build arguments.]({{ site.baseurl }}{% link _docker/getting-started/build-arguments.md %})
 
 ### Volumes
 You can use `volumes` in your `codeship-services.yml` file to persist data between containers as well as between steps in your CI/CD process.


### PR DESCRIPTION
These updates add documentation for the support of build arguments. The following keys are added to the services file:

`args:` (nested in build)
`encrypted_args` (nested in build)
`encrypted_args_file` (nested in build)

In addition, this PR includes updates to the `encryption` article to include instructions for encrypting a build args file, as well as a tutorial article for build arguments.

https://docs.docker.com/engine/reference/builder/#/arg
https://docs.docker.com/compose/compose-file/#/args

https://www.pivotaltracker.com/epic/show/3195541
