### PR TITLE
Fix a syntax error

### DIFF
--- a/_website.json
+++ b/_website.json
@@ -13,7 +13,8 @@
       "HostName": "documentation.codeship.com",
       "ReplaceKeyPrefixWith": "basic/",
       "HttpRedirectCode": "302"
-    },
+    }
+  }, {
     "Condition": {
       "KeyPrefixEquals": "docker/"
     },


### PR DESCRIPTION
The error caused only one redirect rule to be picked up.

I already created the second redirect via the AWS console, but this will make sure it is persisted.