### PR TITLE
Remove private beta note for build args docs

### DIFF
--- a/_pro/getting-started/build-arguments.md
+++ b/_pro/getting-started/build-arguments.md
@@ -11,10 +11,6 @@ category: Getting Started
 * include a table of contents
 {:toc}
 
-<div class="info-block">
-This feature is in private beta. If you are a Codeship customer with projects running on Codeship Pro, contact us at [beta@codeship.com](mailto:beta@codeship.com) to request access to this feature.
-</div>
-
 ## Overview: Build Arguments
 For each service, you can declare [build arguments](https://docs.docker.com/compose/compose-file/#/args), which are values available to the image only at build time. For example, if you must pass the image a set of credentials in order to access an asset or repository when the image is built, you would pass that value to the image as a build argument.
 

--- a/_pro/getting-started/encryption.md
+++ b/_pro/getting-started/encryption.md
@@ -80,11 +80,6 @@ aws:
 
 ## Build Arguments
 
-<div class="info-block">
-Build arguments are in private beta. If you are a Codeship customer with projects running on Codeship Pro, contact us at [beta@codeship.com](mailto:beta@codeship.com) to request access to this feature.
-</div>
-
-
 It might be necessary to pass encrypted values to the image at buildtime. A common use case for this is credentials for a repository or asset needed during the image building process, such as accessing a private gem server. In this case, you can encrypt a file of [build arguments](https://docs.docker.com/compose/compose-file/#/args) that will be passed to the image at build time.
 
 Save the file as e.g. `buildargs.env` in your repository. It could contain the following data


### PR DESCRIPTION
This removes the 'private beta' message on build args doc articles. This should be merged along with the public release of build arguments. https://www.pivotaltracker.com/story/show/136353997