### PR TITLE
Add redirect for bit.ly/codeship-jet-tool

### DIFF
--- a/_pro/getting-started/installation.md
+++ b/_pro/getting-started/installation.md
@@ -11,6 +11,7 @@ tags:
 category: Getting Started
 redirect_from:
   - /docker/installation/
+  - /documentation/docker/installation/
 ---
 
 <div class="info-block">


### PR DESCRIPTION
Tested this locally and it should do the trick to get that bit.ly link working again.