### PR TITLE
Update Yarn installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV \
 	DEBIAN_FRONTEND="noninteractive" \
 	NODE_VERSION="6.x"
 
-# basic project configuration
+# Basic project configuration
 WORKDIR /docs
 EXPOSE 4000
 
@@ -17,17 +17,19 @@ RUN \
 	apt-get install -y --no-install-recommends \
 		apt-transport-https \
 		curl && \
-	curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+	curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
 	echo "deb https://deb.nodesource.com/node_${NODE_VERSION} ${DEBIAN_DISTRIBUTION} main" > /etc/apt/sources.list.d/nodesource.list && \
+	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+	echo "deb https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
 		build-essential \
 		graphicsmagick \
 		libssl1.0.0 \
 		libyaml-0-2 \
-		nodejs && \
+		nodejs \
+		yarn && \
 	ln -s $(which nodejs) /usr/local/bin/node && \
-	npm install --global yarn && \
 	apt-get clean -y && \
 	rm -rf /var/lib/apt/lists/*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Codeship",
-  "homepage": "https://codeship.com/documentation",
+  "homepage": "https://documentation.codeship.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/codeship/documentation.git"
@@ -10,8 +10,8 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "^4.4.4",
-    "npm": "^2.15.1"
+    "node": "^6.9.3",
+    "yarn": "^0.18.1"
   },
   "dependencies": {
     "autoprefixer": "^6.0.0",


### PR DESCRIPTION
Installing Yarn via npm is being deprecated.  This will now install Yarn as recommended by the project.

https://yarnpkg.com/en/docs/install#linux-tab