### PR TITLE
Highlight the active collection

### DIFF
--- a/_includes/documentation_header.html
+++ b/_includes/documentation_header.html
@@ -12,9 +12,15 @@
       {% continue %}
       {% endif %}
       <li>
-        <a href="{{ collection.label | relative_url }}/">
-          {{ collection.title }}
-        </a>
+        {% if collection.shortname == page.collection %}
+          <strong><a href="{{ collection.label | relative_url }}/">
+            {{ collection.title }}
+          </a></strong>
+        {% else %}
+          <a href="{{ collection.label | relative_url }}/">
+            {{ collection.title }}
+          </a>
+        {% endif %}
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
It is difficult to know which collection an article belongs to when you're browsing.  This is a subtle change that will highlight the active collection based on the article you are viewing.

<img width="511" alt="screen shot 2017-01-06 at 5 58 34 pm" src="https://cloud.githubusercontent.com/assets/1104976/21737883/a0d5c3a6-d43a-11e6-891b-e11f83438c01.png">
