### PR TITLE
Redirect /pro/cli/ to the CLI installation doc

### DIFF
--- a/_pro/getting-started/cli.md
+++ b/_pro/getting-started/cli.md
@@ -10,6 +10,7 @@ tags:
 category: Getting Started
 redirect_from:
   - /docker/cli/
+  - /pro/cli/
   - /jet/
 ---
 


### PR DESCRIPTION
https://documentation.codeship.com/pro/cli/ is currently showing a 404 error :(