### PR TITLE
Remove deprecated option and fix require syntax in PHPUnit docs

### DIFF
--- a/_basic/languages-frameworks/php.md
+++ b/_basic/languages-frameworks/php.md
@@ -105,8 +105,8 @@ composer install --prefer-dist --no-interaction
 As we already have a version of PHPUnit preinstalled on our build VMs, you need to remove this version first, before upgrading to a different version via Composer.
 
 ```shell
-composer global remove "phpunit/phpunit" --update-with-dependencies
-composer global require "phpunit/phpunit=5.*"
+composer global remove phpunit/phpunit
+composer global require phpunit/phpunit:5.*
 ```
 
 ### Pecl


### PR DESCRIPTION
Hey guys,

Your [PHP docs](https://documentation.codeship.com/basic/languages-frameworks/php/#phpunit) have a snippet explaining how to change the global composer version on the VM build. This PR addresses a couple things that are slightly out.

1. The `--update-with-dependencies` option for removing a Composer package has been deprecated since [1.0.0-beta2](https://github.com/composer/composer/blob/6c51006309c1692351f4e7f8395616a5946f5e42/CHANGELOG.md#100-beta2---2016-03-27) and results in a warning message. The old behaviour is now the default unless `--no-update-with-dependencies` is specified.

2. The syntax for requiring a package, although functional, does not match that of the Composer docs. Have updated to match.

Thanks!