### PR TITLE
correcting use of dockerfile_path key

### DIFF
--- a/_pro/continuous-deployment/azure.md
+++ b/_pro/continuous-deployment/azure.md
@@ -100,7 +100,7 @@ To interact with the new Docker VM on Azure you configured in the previous step,
 azureappdeploy:
   build:
     image: alpine:latest
-    Dockerfile_path: deployment/Dockerfilessh
+    dockerfile: deployment/Dockerfilessh
   encrypted_env_file:
   - vm.env.encrypted
 ```

--- a/_pro/getting-started/build-arguments.md
+++ b/_pro/getting-started/build-arguments.md
@@ -43,7 +43,7 @@ Now that the Dockerfile knows to expect an argument, you can pass the argument t
 ```bash
 app:
   build:
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
     args:
       build_env: staging
 ```
@@ -71,7 +71,7 @@ Pass that file to your service's build directive.
 ```yaml
 app:
   build:
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
     encrypted_args_file: build_args.encrypted
 ```
 
@@ -80,7 +80,7 @@ If your use case is simple enough, you may want to pass in encrypted values dire
 ```yaml
 app:
   build:
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
     encrypted_args: 8rD1P1xO1CwB4L99JBqnvoSOX+1wimf9qwHXATf9foasPtU6Sw==
 ```
 

--- a/_pro/getting-started/caching.md
+++ b/_pro/getting-started/caching.md
@@ -29,7 +29,7 @@ To use caching on a particular service, you must add a `cached` declaration to y
 app:
   build:
     path: testpath
-    dockerfile_path: Dockerfile.foo
+    dockerfile: Dockerfile.foo
   cached: true
 ```
 
@@ -55,7 +55,7 @@ In some cases, you may want to specify a branch other than `master` to use as yo
 app:
   build:
     path: testpath
-    dockerfile_path: Dockerfile.foo
+    dockerfile: Dockerfile.foo
   cached: true
   default_cache_branch: "branch_name"
 ```

--- a/_pro/getting-started/custom-notifications.md
+++ b/_pro/getting-started/custom-notifications.md
@@ -66,7 +66,7 @@ We'll need to provide this container with the necessary environment variables. T
 deploynotify
   build:
     image: myuser/myrepo-deploynotify
-    dockerfile_path: Dockerfile.notify
+    dockerfile: Dockerfile.notify
   encrypted_env_file: deploy.env.encrypted
 ```
 

--- a/_pro/getting-started/docker-push.md
+++ b/_pro/getting-started/docker-push.md
@@ -44,7 +44,7 @@ git commit -m "Adding encrypted credentials for docker push"
 app:
   build:
     image: username/repository_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
 ```
 
 * Configure your `codeship-steps.yml` file. Your service `image_name` can differ from the repository defined in your steps file. Your image will be tagged and pushed based on the `push` step.
@@ -87,7 +87,7 @@ git commit -m "Adding encrypted credentials for docker push"
 app:
   build:
     image: quay.io/username/repository_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
 ```
 
 * Configure your `codeship-steps.yml` file. Your service `image_name` can differ from the repository defined in your steps file. Your image will be tagged and pushed based on the `push` step.

--- a/_pro/getting-started/dockercfg-services.md
+++ b/_pro/getting-started/dockercfg-services.md
@@ -31,7 +31,7 @@ Taking advantage of this feature is fairly simple. First off, add a service usin
 # codeship-services.yml
 app:
   build:
-    dockerfile_path: ./Dockerfile
+    dockerfile: ./Dockerfile
     image: myservice.com/myuser/myapp
 myservice_generator:
   image: codeship/myservice-dockercfg-generator

--- a/_pro/getting-started/getting-started-part-five.md
+++ b/_pro/getting-started/getting-started-part-five.md
@@ -38,7 +38,7 @@ Let's open up our `codeship-services.yml` file and make a change to enable cachi
 demo:
   build:
     image: myapp
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   links:
     - redis
     - postgres

--- a/_pro/getting-started/getting-started-part-four.md
+++ b/_pro/getting-started/getting-started-part-four.md
@@ -44,7 +44,7 @@ Let's open our services file and find our main application service and make a qu
 demo:
   build:
     image: myapp
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   links:
     - redis
     - postgres
@@ -68,7 +68,7 @@ To read from the volume, we'll need to create a separate service in your `codesh
 demo_volumes:
   build:
     image: myapp
-    dockerfile_path: Dockerfile.volumes
+    dockerfile: Dockerfile.volumes
   volumes_from:
     - demo
 ```

--- a/_pro/getting-started/getting-started-part-two.md
+++ b/_pro/getting-started/getting-started-part-two.md
@@ -44,7 +44,7 @@ Opening up our `codeship-services.yml`, we'll add the following:
 demo:
   build:
     image: myapp
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   links:
     - redis
     - postgres

--- a/_pro/getting-started/getting-started.md
+++ b/_pro/getting-started/getting-started.md
@@ -117,7 +117,7 @@ So, once you've created a file named `codeship-services.yml` go ahead and add th
 demo:
   build:
     image: myapp
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   links:
     - redis
     - postgres

--- a/_pro/getting-started/image-push-fails.md
+++ b/_pro/getting-started/image-push-fails.md
@@ -33,7 +33,7 @@ Note that our **image_name** here is *something/test-repo*. This is the name of 
 demo:
   build:
     image: something/test-repo
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
 ```
 
 Find out more about these two files in [steps configuration]({{ site.baseurl }}{% link _pro/getting-started/steps.md %}) and [services configuration]({{ site.baseurl }}{% link _pro/getting-started/services.md %}).

--- a/_pro/getting-started/services-and-databases.md
+++ b/_pro/getting-started/services-and-databases.md
@@ -51,7 +51,7 @@ ruby:
 elasticsearch:
   build:
     name: my_project/elasticsearch
-    dockerfile_path: Dockerfile.elasticsearch
+    dockerfile: Dockerfile.elasticsearch
 ```
 
 Now we have a fully customized instance of Elasticsearch running. This same process applies to any other service or database you might be using. To see how to customize them take a look at the specific Dockerfiles that are used to create the service you want to use.

--- a/_pro/getting-started/services.md
+++ b/_pro/getting-started/services.md
@@ -112,7 +112,7 @@ An example setup using volumes in your `codeship-services.yml` file would look l
 app:
   build:
     image: codeship/app
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   volumes_from:
     - data
 data:
@@ -134,7 +134,7 @@ An example setup explicitly declaring your environment variables in your `codesh
 app:
   build:
     image: codeship/app
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   environment:
     ENV: string
     ENV2: string
@@ -146,7 +146,7 @@ An example setup providing your encrypted environment variable file in your `cod
 app:
   build:
     image: codeship/app
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   encrypted_env_file: env.encrypted
 ```
 
@@ -174,7 +174,7 @@ An example setup using caching in your `codeship-services.yml` file would look l
 app:
   build:
     image: codeship/app
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   cached: true
 ```
 

--- a/_pro/languages-frameworks/go.md
+++ b/_pro/languages-frameworks/go.md
@@ -55,7 +55,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/_pro/languages-frameworks/java.md
+++ b/_pro/languages-frameworks/java.md
@@ -87,7 +87,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/_pro/languages-frameworks/nodejs.md
+++ b/_pro/languages-frameworks/nodejs.md
@@ -56,7 +56,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/_pro/languages-frameworks/php.md
+++ b/_pro/languages-frameworks/php.md
@@ -81,7 +81,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile.ci
+    dockerfile: Dockerfile.ci
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/_pro/languages-frameworks/python.md
+++ b/_pro/languages-frameworks/python.md
@@ -53,7 +53,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/_pro/languages-frameworks/ruby.md
+++ b/_pro/languages-frameworks/ruby.md
@@ -71,7 +71,7 @@ When accessing other containers please be aware that those services do not run o
 project_name:
   build:
     image: organisation_name/project_name
-    dockerfile_path: Dockerfile.ci
+    dockerfile: Dockerfile.ci
   # Linking Redis and Postgres into the container
   links:
     - redis

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,14 +1,14 @@
 documentation:
   build:
     image: codeship/documentation
-    dockerfile_path: Dockerfile
+    dockerfile: Dockerfile
   encrypted_env_file: deployment.env.encrypted
   cached: true
   volumes_from:
     - data
 aws:
   build:
-    dockerfile_path: Dockerfile.aws
+    dockerfile: Dockerfile.aws
   cached: true
   volumes_from:
     - data


### PR DESCRIPTION
we say that use of `dockerfile_path` is deprecated, but almost all examples used it 😄 
this PR should correct the examples 