### PR TITLE
Force removing branding on ratings

### DIFF
--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -251,6 +251,10 @@ body.is-blue {
   margin: 1rem 0;
 }
 
+div#rating_info_8520732 {
+  display: none !important;
+}
+
 // *******************************************************
 // Newsletter Subscribe
 // *******************************************************


### PR DESCRIPTION
Only using !important short-term until paid account lets us term off branding.