### PR TITLE
Draft one articles for repo scenarios

### DIFF
--- a/_pro/continuous-deployment/ssh-deploy.md
+++ b/_pro/continuous-deployment/ssh-deploy.md
@@ -8,8 +8,6 @@ tags:
   - ssh key
   - encryption
 
-redirect_from:
-  - /docker/ssh-key-authentication/
 ---
 
 <div class="info-block">

--- a/_pro/continuous-deployment/ssh-deploy.md
+++ b/_pro/continuous-deployment/ssh-deploy.md
@@ -1,10 +1,10 @@
 ---
-title: "Tutorial: Configure SSH Key Authentication"
+title: "Deploy Via SSH With Codeship Pro"
 layout: page
-weight: 41
+weight: 45
 tags:
   - docker
-  - tutorial
+  - deployment
   - ssh key
   - encryption
 
@@ -19,13 +19,13 @@ To follow this tutorial on your own computer, please [install the `jet` CLI loca
 * include a table of contents
 {:toc}
 
-During your build you might want to access other repositories to pull in dependencies or push your code to other servers.
+## Using SSH/SCP To Deploy
+
+To deploy using SSH and SCP with Codeship Pro, you will need to create a container that can connect to your server via SSH. Then, you will pass this container the necessary deployment commands.
 
 To do this you need to set up an encrypted SSH Key that is available as an environment variable and can be written to the `.ssh` folder.
 
-We will walk you through an example that will set up a key, encrypt it and make it available during the build. For cloning from Github another option is to use their [OAuth Key instead of an SSH key](https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth).
-
-## Create an SSH Key
+## Creating Your SSH Key
 
 The following command will create two files in your local repository. `keyfile.rsa` contains your private key that we will encrypt and put into your repository. This encrypted file will be decrypted on Codeship as part of your build. The second file `keyfile.rsa.pub` can be added to services that you want to access.
 
@@ -49,11 +49,20 @@ app:
   encrypted_env_file: sshkey.env.encrypted
 ```
 
-## Setup during the build
+## Using The Key During The Build
 
 Before running a command that needs SSH available make sure to run the following commands in that container. They will set up the SSH key so you can access external services.
 
 ```bash
 mkdir -p "$HOME/.ssh"
 echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
+```
+
+## Deploying Your Code
+
+Once you've established your SSH connection, you will want to deploy your code. This is accomplished via your [codeship-steps.yml]({{ site.baseurl }}{% link _pro/getting-started/steps.md %}) file by using SSH deployment commands with your authenticated container.
+
+```yaml
+- service: ssh
+  command: scp -rp . ssh_user@your.server.com:/path/on/server/
 ```

--- a/_pro/getting-started/cloning-repos.md
+++ b/_pro/getting-started/cloning-repos.md
@@ -1,0 +1,95 @@
+---
+title: "Using Multiple Repos In Your Build"
+layout: page
+weight: 41
+tags:
+  - docker
+  - tutorial
+  - ssh key
+  - encryption
+  - repo
+
+redirect_from:
+  - /docker/ssh-key-authentication/
+  - /pro/getting-started/ssh-key-authentication/
+---
+
+<div class="info-block">
+To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% link _pro/getting-started/installation.md %}).
+</div>
+
+* include a table of contents
+{:toc}
+
+## Multi-Repo Build Pipelines
+
+When using microservices, you may have several repos you want to build together or in sequences. There are two primary setups to accomplish this, and for each setup there are a couple of methods you can use.
+
+- You can create separate CI/CD projects for each repository, allowing them to deploy independently of one another. Then, you can either have each project bring in all of your individual component repos for full-stack testing, or you can create a separate, agnostic project just for the purposes of combining them for full-stack testing.
+
+- You can create a single project that pulls from all of your repos, deploying all components together whenever the master project is updated.
+
+Once you decide which workflow you like, there are two main ways to combine your repos for full-stack  testing.
+
+## Using Image Pushes
+
+If you opt to create separate CI/CD projects for each individual component, you can have each component's pipeline end with an [image push]({{ site.baseurl }}{% link _pro/getting-started/steps.md %}) to an image registry.
+
+Then, either with a separate project or as a part of the build process for each component, you can pull in the latest images for each component to build and test your combined application.
+
+## Cloning Multiple Repos During A Build
+
+In addition to the above method using images in a regsitry, you can also clone the repos themsleves during the build process - either with a separate project or as part of the build for each individual component.
+
+### Creating Your SSH Key
+
+The first step of cloning a repo into your build process is to create your SSH key authentication. Another optoin for cloning from Github would  be to use their [OAuth Key instead of an SSH key](https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth).
+
+The following command will create two files in your local repository. `keyfile.rsa` contains your private key that we will encrypt and put into your repository. This encrypted file will be decrypted on Codeship as part of your build. The second file `keyfile.rsa.pub` can be added to services that you want to access.
+
+```bash
+ssh-keygen -t rsa -b 4096 -C "your_email@example.com" -f keyfile.rsa
+```
+
+Now you have to copy the content of `keyfile.rsa` into an environment file `sshkey.env`. Make sure to replace newlines with \n so the whole SSH key is in one line. The following is an example of ssh_key.env.
+
+```bash
+PRIVATE_SSH_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCFgEA2LcSb6INQUVZZ0iZJYYkc8dMHLLqrmtIrzZ...
+```
+
+After preparing the `sshkey.env` file we can encrypt it with Jet. Follow the [encryption tutorial]({{ site.baseurl }}{% link _pro/getting-started/environment-variables.md %}) to turn the `sshkey.env` file into a `sshkey.env.encrypted` file.
+
+You can then add it to a service with the `encrypted_env_file` option. It will be automatically decrypted on Codeship.
+
+```yaml
+app:
+  build: .
+  encrypted_env_file: sshkey.env.encrypted
+```
+
+### Using The Key During The Build
+
+Before running a command that needs SSH available make sure to run the following commands in that container. They will set up the SSH key so you can access external services.
+
+```bash
+mkdir -p "$HOME/.ssh"
+echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
+```
+
+### Cloning Another Repo
+
+Once you have the SSH authentication working, then you'll just need a Dockerfile that grabs git and clones the repo you want:
+
+```yaml
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y ca-certificates git-core ssh
+mkdir -p "$HOME/.ssh"
+echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
+RUN git clone repo:repo.git
+```
+
+Note that this is a high-level, directional example and will require additional work to use in a live build.
+
+## Building With Repos Via API
+
+Codeship Pro does not yet have an API for triggering building, but we will be launching an API for this purpose later in 2017.

--- a/_pro/getting-started/cloning-repos.md
+++ b/_pro/getting-started/cloning-repos.md
@@ -43,7 +43,7 @@ In addition to the above method using images in a regsitry, you can also clone t
 
 ### Creating Your SSH Key
 
-The first step of cloning a repo into your build process is to create your SSH key authentication. Another optoin for cloning from Github would  be to use their [OAuth Key instead of an SSH key](https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth).
+The first step of cloning a repo into your build process is to create your SSH key authentication. Another option for cloning from GitHub would be to use [OAuth instead of an SSH key](https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth).
 
 The following command will create two files in your local repository. `keyfile.rsa` contains your private key that we will encrypt and put into your repository. This encrypted file will be decrypted on Codeship as part of your build. The second file `keyfile.rsa.pub` can be added to services that you want to access.
 
@@ -80,11 +80,12 @@ echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
 
 Once you have the SSH authentication working, then you'll just need a Dockerfile that grabs git and clones the repo you want:
 
-```yaml
+```bash
 FROM ubuntu:latest
+COPY .
 RUN apt-get update && apt-get install -y ca-certificates git-core ssh
-mkdir -p "$HOME/.ssh"
-echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
+RUN mkdir -p "$HOME/.ssh"
+RUN echo -e $PRIVATE_SSH_KEY >> $HOME/.ssh/id_rsa
 RUN git clone repo:repo.git
 ```
 
@@ -92,4 +93,4 @@ Note that this is a high-level, directional example and will require additional 
 
 ## Building With Repos Via API
 
-Codeship Pro does not yet have an API for triggering building, but we will be launching an API for this purpose later in 2017.
+Codeship Pro does not yet have an API for triggering builds, but we will be launching an API for this purpose later in 2017.


### PR DESCRIPTION
- Turning existing SSH article into multi-repo article
- Creating separate SSH deployment article

Added cards to Trello to circle back and improve code examples for both, but have short-term need for example to be up.