### PR TITLE
Dependency Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.4.1"
 # https://github.com/jekyll/jekyll-redirect-from/issues/150
 Encoding.default_external = Encoding::UTF_8
 
+gem 'rake', '~>12.0.0'
 gem 'jekyll', '~> 3.4.0'
 gem 'rouge', '~> 1.11.1'
 gem 'sass', '~> 3.4.23'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ Encoding.default_external = Encoding::UTF_8
 
 gem 'rake', '~>12.0.0'
 gem 'jekyll', '~> 3.4.0'
-gem 'rouge', '~> 1.11.1'
 gem 'sass', '~> 3.4.23'
 
 # Jekyll plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ DEPENDENCIES
   jekyll-redirect-from (~> 0.12.1)
   jekyll-seo-tag (~> 2.2.0)
   jekyll-sitemap (~> 1.1.1)
-  rouge (~> 1.11.1)
+  rake (~> 12.0.0)
   sass (~> 3.4.23)
   scss_lint
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,44 @@
+IMAGE_NAME = 'codeship/documentation'
+
+desc "Build the #{IMAGE_NAME} image"
+task :build do
+	sh "docker build --tag #{IMAGE_NAME} ."
+end
+
+desc 'Run the development server'
+task :serve do
+	sh "docker run -it --rm -p 4000:4000 -v $(pwd):/docs #{IMAGE_NAME}"
+end
+
+desc 'Update Ruby and NodeJS based dependencies'
+task update: %w[build update:rubygems update:yarn]
+namespace :update do
+	desc 'Update Ruby based dependencies'
+	task rubygems: %w[build] do
+		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} bundle update"
+	end
+
+	desc 'Update NodeJS based dependencies'
+	task yarn: %w[build] do
+		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} yarn upgrade"
+	end
+end
+
+desc "Run Linters"
+task lint: %w[lint:scss lint:json lint:jekyll]
+namespace :lint do
+	desc 'Run SCSS linter'
+	task :scss do
+		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} bundle exec scss-lint"
+	end
+
+	desc 'Run JSON linter'
+	task :json do
+		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} gulp lint"
+	end
+
+	desc 'Run Jekyll configuration linter'
+	task :jekyll do
+		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} bundle exec jekyll doctor"
+	end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,8 +49,8 @@ arr-diff@^2.0.0:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -208,8 +208,8 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000653"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000653.tgz#123e112a29ce8f3199e4995d2d8b9d95492c5b41"
+  version "1.0.30000656"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000656.tgz#127c8c6e655e7464e58f039558f1e878fcca3c45"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -505,8 +505,8 @@ each-async@^1.0.0, each-async@^1.1.1:
     set-immediate-shim "^1.0.0"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.3.tgz#651eb63fe89f39db70ffc8dbd5d9b66958bc6a0e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.5.tgz#6cd6ff2106224a6130e235f21050f9546bc3e729"
 
 end-of-stream@1.0.0, end-of-stream@^1.0.0:
   version "1.0.0"
@@ -1003,7 +1003,7 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
-gulp-util@3.0.7:
+gulp-util@3.0.7, gulp-util@^3.0.0, gulp-util@^3.0.6:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.7.tgz#78925c4b8f8b49005ac01a011c557e6218941cbb"
   dependencies:
@@ -1039,7 +1039,7 @@ gulp-util@^2.2.14:
     through2 "^0.5.0"
     vinyl "^0.2.1"
 
-gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.6, gulp-util@^3.0.8:
+gulp-util@^3.0.1, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -1119,8 +1119,8 @@ homedir-polyfill@^1.0.0:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.1.tgz#4b0445e41c004a8bd1337773a4ff790ca40318c8"
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
 imagemin-gifsicle@^4.0.0:
   version "4.2.0"
@@ -1197,8 +1197,8 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
 interpret@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.2.tgz#f4f623f0bb7122f15f5717c8e254b8161b5c5b2d"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 ip-regex@^1.0.1:
   version "1.0.3"
@@ -1306,8 +1306,8 @@ is-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-png@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-png/-/is-png-1.0.0.tgz#3d80373fe9b89d65fd341f659d3fc0a1135e718a"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-png/-/is-png-1.1.0.tgz#d574b12bf275c0350455570b0e5b57ab062077ce"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -2073,8 +2073,8 @@ postcss-value-parser@^3.2.3:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
 postcss@^5.2.12, postcss@^5.2.16:
-  version "5.2.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.16.tgz#732b3100000f9ff8379a48a53839ed097376ad57"
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"
@@ -2235,8 +2235,8 @@ resolve-dir@^0.1.0:
     global-modules "^0.2.3"
 
 resolve@^1.1.6, resolve@^1.1.7:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
 
@@ -2607,8 +2607,8 @@ uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 v8flags@^2.0.2:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.0.12.tgz#73235d9f7176f8e8833fb286795445f7938d84e5"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
   dependencies:
     user-home "^1.1.1"
 


### PR DESCRIPTION
And some groundwork to make this easier.

I added Rake tasks for common tasks we need to run

* `rake build` builds the Docker image
* `rake serve` serves the documentation via Docker on port `4000` of the Docker host
* `rake update` updates Ruby and NodeJS based dependencies
* `rake lint` runs the linters, all via Docker containers

I also ran `rake update` to get the latest versions of all dependencies and I removed the explicit dependency on Rouge, which is now handled by Jekyll itself. (Rouge wasn't always the default highlighter for Jekyll, but has been since a couple months.)