### PR TITLE
Rewrite the menu implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'jekyll-coffeescript', '~> 1.0.2'
 gem 'jekyll-seo-tag', '~> 2.2.0'
 gem 'jekyll-sitemap', '~> 1.1.1'
 gem 'jekyll-redirect-from', '~> 0.12.1'
+gem 'jekyll-menus', '~> 0.5.0'
 
 group :test do
   gem 'scss_lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
     jekyll-coffeescript (1.0.2)
       coffee-script (~> 2.2)
       coffee-script-source (~> 1.11.1)
+    jekyll-menus (0.5.0)
+      jekyll (~> 3.1)
     jekyll-redirect-from (0.12.1)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
@@ -61,6 +63,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.4.0)
   jekyll-coffeescript (~> 1.0.2)
+  jekyll-menus (~> 0.5.0)
   jekyll-redirect-from (~> 0.12.1)
   jekyll-seo-tag (~> 2.2.0)
   jekyll-sitemap (~> 1.1.1)

--- a/_basic/builds-and-configuration/api.md
+++ b/_basic/builds-and-configuration/api.md
@@ -1,11 +1,13 @@
 ---
 title: Using The Codeship API For CI/CD Workflows
 layout: page
-weight: 11
+menus:
+  basic/builds:
+    title: API
+    weight: 11
 tags:
   - api
   - integrations
-
 redirect_from:
   - /integrations/api/
   - /basic/getting-started/api/

--- a/_basic/builds-and-configuration/dependency-cache.md
+++ b/_basic/builds-and-configuration/dependency-cache.md
@@ -1,12 +1,14 @@
 ---
 title: Speed Up Your Builds With Caching on Codeship Basic
-weight: 4
+menus:
+  basic/builds:
+    title: Caching
+    weight: 4
 tags:
   - cache
   - dependencies
   - speed
   - caching
-
 redirect_from:
   - /basic/getting-started/dependency-cache/
 ---

--- a/_basic/builds-and-configuration/deployment-pipelines.md
+++ b/_basic/builds-and-configuration/deployment-pipelines.md
@@ -1,16 +1,17 @@
 ---
 title: Deployment Pipelines On Codeship Basic
 layout: page
-weight: 6
+menus:
+  basic/builds:
+    title: Deployment Pipelines
+    weight: 6
 tags:
   - deployment
-
 redirect_from:
   - /continuous-deployment/deployment-pipelines/
   - /basic/getting-started/wildcard-deployment-pipelines/
   - /basic/getting-started/deployment-pipelines/
   - /continuous-deployment/wildcard-deployment-pipelines/
-
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/ignore-command-on-branch.md
+++ b/_basic/builds-and-configuration/ignore-command-on-branch.md
@@ -1,15 +1,17 @@
 ---
 title: Ignore command on specific branch or run only on a branch
 layout: page
-weight: 8
+menus:
+  basic/builds:
+    title: Ignoring Commands
+    weight: 8
 tags:
   - faq
   - commands
   - branch
-
 redirect_from:
   - /faq/ignore-command-on-branch/
-  - /basic/getting-started/ignore-command-on-branch/  
+  - /basic/getting-started/ignore-command-on-branch/
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/packages.md
+++ b/_basic/builds-and-configuration/packages.md
@@ -1,11 +1,13 @@
 ---
 title: All Packages Installed On Codeship Basic
-weight: 1
+menus:
+  basic/builds:
+    title: Installed Packages
+    weight: 1
 tags:
 - AMI
 - continuous integration
 - packages
-
 redirect_from:
   - /basic/getting-started/packages/
 ---

--- a/_basic/builds-and-configuration/parallelci.md
+++ b/_basic/builds-and-configuration/parallelci.md
@@ -1,12 +1,14 @@
 ---
 title: Speed Up Your Builds With Parallel Testing on Codeship Basic
-weight: 5
+menus:
+  basic/builds:
+    title: Parallel Testing
+    weight: 5
 tags:
 - testing
 - continuous integration
 - parallelci
 - parallelism
-
 redirect_from:
   - /continuous-integration/parallelci/
   - /basic/getting-started/parallelci/

--- a/_basic/builds-and-configuration/root-level-access.md
+++ b/_basic/builds-and-configuration/root-level-access.md
@@ -1,16 +1,18 @@
 ---
 title: Running Commands As Sudo or Root
 layout: page
-weight: 7
+menus:
+  basic/builds:
+    title: Running Commands As Root
+    weight: 7
 tags:
   - faq
   - sudo
   - packages
   - root
-
 redirect_from:
   - /faq/root-level-access/
-  - /basic/getting-started/root-level-access/  
+  - /basic/getting-started/root-level-access/
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/run-command-if-other-fails.md
+++ b/_basic/builds-and-configuration/run-command-if-other-fails.md
@@ -1,16 +1,17 @@
 ---
 title: Run A Fallback Command After Another Command Fails
 layout: page
-weight: 9
+menus:
+  basic/builds:
+    title: Run A Command In Case Of An Error
+    weight: 9
 tags:
   - faq
   - build error
   - commands
-
 redirect_from:
   - /faq/run-command-if-other-fails/
-  - /basic/getting-started/run-command-if-other-fails/  
-
+  - /basic/getting-started/run-command-if-other-fails/
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/set-environment-variables.md
+++ b/_basic/builds-and-configuration/set-environment-variables.md
@@ -1,13 +1,15 @@
 ---
 title: Environment Variables On Codeship Basic
-weight: 2
+menus:
+  basic/builds:
+    title: Environment Variables
+    weight: 2
 tags:
   - testing
   - environment variables
-
 redirect_from:
   - /continuous-integration/set-environment-variables/
-  - /basic/getting-started/set-environment-variables/   
+  - /basic/getting-started/set-environment-variables/
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/ssh-access.md
+++ b/_basic/builds-and-configuration/ssh-access.md
@@ -1,16 +1,18 @@
 ---
 title: Debugging Your Builds Via SSH Sessions
-weight: 3
+menus:
+  basic/builds:
+    title: Debugging Builds
+    weight: 3
 tags:
   - testing
   - ssh
   - key
   - debug
   - troubleshooting
-
 redirect_from:
   - /continuous-integration/ssh-access/
-  - /basic/getting-started/ssh-access/  
+  - /basic/getting-started/ssh-access/
 ---
 
 * include a table of contents

--- a/_basic/builds-and-configuration/timezone.md
+++ b/_basic/builds-and-configuration/timezone.md
@@ -1,10 +1,12 @@
 ---
 title: Setting Timezone
 layout: page
-weight: 10
+menus:
+  basic/builds:
+    title: Customizing The Timzone
+    weight: 10
 tags:
   - timezone
-
 redirect_from:
   - /basic/getting-started/timezone/
 ---

--- a/_basic/continuous-deployment/deployment-to-anynines.md
+++ b/_basic/continuous-deployment/deployment-to-anynines.md
@@ -3,7 +3,10 @@ title: Deploy to anynines
 tags:
   - deployment
   - anynines
-weight: 4
+menus:
+  basic/cd:
+    title: anynines
+    weight: 14
 redirect_from:
   - /continuous-deployment/deployment-to-anynines/
 ---

--- a/_basic/continuous-deployment/deployment-to-aws-codedeploy.md
+++ b/_basic/continuous-deployment/deployment-to-aws-codedeploy.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to AWS CodeDeploy
-weight: 8
-layout: page
+menus:
+  basic/cd:
+    title: AWS CodeDeploy
+    weight: 5
 tags:
   - deployment
   - amazon

--- a/_basic/continuous-deployment/deployment-to-aws-lambda.md
+++ b/_basic/continuous-deployment/deployment-to-aws-lambda.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to AWS Lambda
-weight: 9
-layout: page
+menus:
+  basic/cd:
+    title: AWS Lambda
+    weight: 6
 tags:
   - deployment
   - amazon

--- a/_basic/continuous-deployment/deployment-to-cloudfoundry.md
+++ b/_basic/continuous-deployment/deployment-to-cloudfoundry.md
@@ -3,10 +3,10 @@ title: Deploy with Cloud Foundry
 tags:
   - deployment
   - cloudfoundry
-  menus:
-    basic/cd:
-      title: Cloud Foundry
-      weight: 12
+menus:
+  basic/cd:
+    title: Cloud Foundry
+    weight: 12
 redirect_from:
   - /continuous-deployment/deployment-to-cloudfoundry/
 ---

--- a/_basic/continuous-deployment/deployment-to-cloudfoundry.md
+++ b/_basic/continuous-deployment/deployment-to-cloudfoundry.md
@@ -3,7 +3,10 @@ title: Deploy with Cloud Foundry
 tags:
   - deployment
   - cloudfoundry
-weight: 12
+  menus:
+    basic/cd:
+      title: Cloud Foundry
+      weight: 12
 redirect_from:
   - /continuous-deployment/deployment-to-cloudfoundry/
 ---

--- a/_basic/continuous-deployment/deployment-to-digitalocean.md
+++ b/_basic/continuous-deployment/deployment-to-digitalocean.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to DigitalOcean
-layout: page
-weight: 5
+menus:
+  basic/cd:
+    title: Digital Ocean
+    weight: 8
 tags:
   - deployment
   - digital ocean

--- a/_basic/continuous-deployment/deployment-to-elastic-beanstalk.md
+++ b/_basic/continuous-deployment/deployment-to-elastic-beanstalk.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to Elastic Beanstalk
-weight: 4
-layout: page
+menus:
+  basic/cd:
+    title: AWS Elastic Beanstalk
+    weight: 4
 tags:
   - deployment
   - elastic beanstalk

--- a/_basic/continuous-deployment/deployment-to-google-app-engine.md
+++ b/_basic/continuous-deployment/deployment-to-google-app-engine.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to Google App Engine
-weight: 6
-layout: page
+menus:
+  basic/cd:
+    title: Google App Engine
+    weight: 9
 tags:
   - deployment
   - google app engine

--- a/_basic/continuous-deployment/deployment-to-heroku.md
+++ b/_basic/continuous-deployment/deployment-to-heroku.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy to Heroku
-weight: 3
-layout: page
+menus:
+  basic/cd:
+    title: Heroku
+    weight: 3
 tags:
   - deployment
   - heroku

--- a/_basic/continuous-deployment/deployment-with-ansible.md
+++ b/_basic/continuous-deployment/deployment-with-ansible.md
@@ -1,6 +1,9 @@
 ---
 title: Deploy via Ansible
-layout: page
+menus:
+  basic/cd:
+    title: Ansible
+    weight: 15
 published: false
 tags:
   - deployment

--- a/_basic/continuous-deployment/deployment-with-awscli.md
+++ b/_basic/continuous-deployment/deployment-with-awscli.md
@@ -1,7 +1,9 @@
 ---
 title: Deployment with AWS CLI
-weight: 7
-layout: page
+menus:
+  basic/cd:
+    title: AWS CLI
+    weight: 7
 tags:
   - deployment
   - aws

--- a/_basic/continuous-deployment/deployment-with-capistrano.md
+++ b/_basic/continuous-deployment/deployment-with-capistrano.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy via Capistrano
-layout: page
-weight: 11
+menus:
+  basic/cd:
+    title: Capistrano
+    weight: 10
 tags:
   - deployment
   - capistrano

--- a/_basic/continuous-deployment/deployment-with-cloud66.md
+++ b/_basic/continuous-deployment/deployment-with-cloud66.md
@@ -3,7 +3,10 @@ title: Deploy via Cloud66
 tags:
   - deployment
   - cloud66
-weight: 13
+menus:
+  basic/cd:
+    title: Cloud66
+    weight: 13
 redirect_from:
   - /continuous-deployment/deployment-with-cloud66/
 ---

--- a/_basic/continuous-deployment/deployment-with-custom-scripts.md
+++ b/_basic/continuous-deployment/deployment-with-custom-scripts.md
@@ -1,7 +1,9 @@
 ---
 title: Deploy via Custom Script
-weight: 2
-layout: page
+menus:
+  basic/cd:
+    title: Custom Script
+    weight: 2
 tags:
   - deployment
   - custom

--- a/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
+++ b/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
@@ -1,6 +1,9 @@
 ---
 title: Deploy via FTP, SFTP, SCP, RSYNC, and SSH
-weight: 1
+menus:
+  basic/cd:
+    title: FTP/SSH/SFTP/RSYNC
+    weight: 1
 tags:
   - deployment
   - ftp

--- a/_basic/continuous-deployment/push-to-remote-repository.md
+++ b/_basic/continuous-deployment/push-to-remote-repository.md
@@ -1,7 +1,9 @@
 ---
 title: Push to Remote Repository
-weight: 10
-layout: page
+menus:
+  basic/cd:
+    title: Git Push
+    weight: 11
 tags:
   - deployment
   - git

--- a/_basic/continuous-integration/browser-testing.md
+++ b/_basic/continuous-integration/browser-testing.md
@@ -1,6 +1,9 @@
 ---
 title: Browser Testing During CI/CD With Codeship Basic
-weight: 1
+menus:
+  basic/ci:
+    title: Browser Testing
+    weight: 1
 tags:
   - testing
   - continuous integration

--- a/_basic/continuous-integration/git-submodules.md
+++ b/_basic/continuous-integration/git-submodules.md
@@ -1,6 +1,9 @@
 ---
 title: Using Git Submodules In CI/CD with Codeship Basic
-weight: 3
+menus:
+  basic/ci:
+    title: Git Submodules
+    weight: 3
 tags:
   - git
   - submodules

--- a/_basic/continuous-integration/keep-build-artifacts.md
+++ b/_basic/continuous-integration/keep-build-artifacts.md
@@ -1,6 +1,9 @@
 ---
 title: Keeping Build Artifacts After CI/CD
-weight: 4
+menus:
+  basic/ci:
+    title: Artifacts
+    weight: 4
 tags:
   - faq
   - artifacts

--- a/_basic/continuous-integration/run-a-command-in-the-background.md
+++ b/_basic/continuous-integration/run-a-command-in-the-background.md
@@ -1,6 +1,9 @@
 ---
 title: Run a command in the background
-weight: 2
+menus:
+  basic/ci:
+    title: Background Commands
+    weight: 2
 tags:
   - testing
   - faq

--- a/_basic/continuous-integration/using-subdomains.md
+++ b/_basic/continuous-integration/using-subdomains.md
@@ -1,6 +1,9 @@
 ---
 title: Custom DNS Resolution
-weight: 6
+menus:
+  basic/ci:
+    title: Custom DNS
+    weight: 5
 tags:
   - subdomain
   - testing

--- a/_basic/databases/cassandra.md
+++ b/_basic/databases/cassandra.md
@@ -5,7 +5,10 @@ tags:
   - services
   - databases
   - cassandra
-weight: 5
+menus:
+  basic/db:
+    title: Apache Cassandra
+    weight: 5
 redirect_from:
   - /databases/cassandra/
   - /classic/getting-started/cassandra/

--- a/_basic/databases/mongodb.md
+++ b/_basic/databases/mongodb.md
@@ -5,7 +5,10 @@ tags:
   - services
   - databases
   - mongodb
-weight: 3
+menus:
+  basic/db:
+    title: MongoDB
+    weight: 3
 redirect_from:
   - /databases/mongodb/
   - /classic/getting-started/mongodb/

--- a/_basic/databases/mysql.md
+++ b/_basic/databases/mysql.md
@@ -1,11 +1,14 @@
 ---
-title: Using MySQL In CI/CD with Codeship Basic 
+title: Using MySQL In CI/CD with Codeship Basic
 layout: page
 tags:
   - services
   - databases
   - mysql
-weight: 1
+menus:
+  basic/db:
+    title: MySQL
+    weight: 1
 redirect_from:
   - /databases/mysql/
   - /classic/getting-started/mysql/

--- a/_basic/databases/postgresql.md
+++ b/_basic/databases/postgresql.md
@@ -5,7 +5,10 @@ tags:
   - services
   - databases
   - postgresql
-weight: 2
+menus:
+  basic/db:
+    title: PostgreSQL
+    weight: 2
 redirect_from:
   - /databases/postgresql/
   - /classic/getting-started/postgresql/

--- a/_basic/databases/rethinkdb.md
+++ b/_basic/databases/rethinkdb.md
@@ -5,7 +5,10 @@ tags:
   - services
   - databases
   - rethinkdb
-weight: 6
+menus:
+  basic/db:
+    title: RethinkDB
+    weight: 6
 redirect_from:
   - /databases/rethinkdb/
   - /classic/getting-started/rethinkdb/

--- a/_basic/databases/sqlite.md
+++ b/_basic/databases/sqlite.md
@@ -5,7 +5,10 @@ tags:
   - services
   - databases
   - sqlite
-weight: 4
+menus:
+  basic/db:
+    title: SQLite
+    weight: 4
 redirect_from:
   - /databases/sqlite/
   - /classic/getting-started/sqlite/

--- a/_basic/languages-frameworks/dart.md
+++ b/_basic/languages-frameworks/dart.md
@@ -1,9 +1,12 @@
 ---
-title: Using Dart In CI/CD with Codeship Basic 
+title: Using Dart In CI/CD with Codeship Basic
 tags:
   - dart
   - languages
-weight: 8
+menus:
+  basic/languages:
+    title: Dart
+    weight: 8
 redirect_from:
   - /languages/dart/
 ---

--- a/_basic/languages-frameworks/elixir.md
+++ b/_basic/languages-frameworks/elixir.md
@@ -3,7 +3,10 @@ title: Using Elixir In CI/CD with Codeship Basic
 tags:
   - elixir
   - languages
-weight: 5
+menus:
+  basic/languages:
+    title: Elixir
+    weight: 5
 ---
 
 * include a table of contents

--- a/_basic/languages-frameworks/go.md
+++ b/_basic/languages-frameworks/go.md
@@ -3,7 +3,10 @@ title: Using Go In CI/CD with Codeship Basic
 tags:
 - go
 - languages
-weight: 6
+menus:
+  basic/languages:
+    title: Go
+    weight: 6
 redirect_from:
   - /languages/go/
 ---

--- a/_basic/languages-frameworks/java-and-jvm-based-languages.md
+++ b/_basic/languages-frameworks/java-and-jvm-based-languages.md
@@ -4,7 +4,10 @@ tags:
   - java
   - scala
   - languages
-weight: 7
+menus:
+  basic/languages:
+    title: Java And JVM
+    weight: 7
 redirect_from:
   - /languages/java-and-jvm-based-languages/
 ---

--- a/_basic/languages-frameworks/nodejs.md
+++ b/_basic/languages-frameworks/nodejs.md
@@ -1,6 +1,9 @@
 ---
 title: Using Node.js In CI/CD with Codeship Basic
-weight: 2
+menus:
+  basic/languages:
+    title: Node.js
+    weight: 2
 tags:
   - nodejs
   - iojs

--- a/_basic/languages-frameworks/php.md
+++ b/_basic/languages-frameworks/php.md
@@ -1,6 +1,9 @@
 ---
 title: Using PHP In CI/CD with Codeship Basic
-weight: 3
+menus:
+  basic/languages:
+    title: PHP
+    weight: 3
 tags:
   - php
   - languages

--- a/_basic/languages-frameworks/python.md
+++ b/_basic/languages-frameworks/python.md
@@ -1,6 +1,9 @@
 ---
 title: Using Python In CI/CD with Codeship Basic
-weight: 4
+menus:
+  basic/languages:
+    title: Python
+    weight: 4
 tags:
   - python
   - languages

--- a/_basic/languages-frameworks/ruby.md
+++ b/_basic/languages-frameworks/ruby.md
@@ -1,6 +1,9 @@
 ---
 title: Using Ruby In CI/CD with Codeship Basic
-weight: 1
+menus:
+  basic/languages:
+    title: Ruby
+    weight: 1
 tags:
   - ruby
   - languages

--- a/_basic/languages-frameworks/rust.md
+++ b/_basic/languages-frameworks/rust.md
@@ -4,7 +4,10 @@ tags:
 - rust
 - cargo
 - languages
-weight: 9
+menus:
+  basic/languages:
+    title: Rust
+    weight: 9
 ---
 
 * include a table of contents

--- a/_basic/queues/beanstalkd.md
+++ b/_basic/queues/beanstalkd.md
@@ -5,7 +5,10 @@ tags:
   - services
   - queues
   - beanstalkd
-weight: 2
+menus:
+  basic/queues:
+    title: Beanstalkd
+    weight: 2
 redirect_from:
   - /queues/beanstalkd/
   - /classic/getting-started/beanstalkd/

--- a/_basic/queues/rabbitmq.md
+++ b/_basic/queues/rabbitmq.md
@@ -5,7 +5,10 @@ tags:
   - services
   - queues
   - rabbitmq
-weight: 3
+menus:
+  basic/queues:
+    title: RabbitMQ
+    weight: 1
 redirect_from:
   - /queues/rabbitmq/
   - /classic/getting-started/rabbitmq/

--- a/_basic/queues/redis.md
+++ b/_basic/queues/redis.md
@@ -5,7 +5,10 @@ tags:
   - services
   - queues
   - redis
-weight: 1
+menus:
+  basic/queues:
+    title: Redis
+    weight: 1
 redirect_from:
   - /queues/redis/
   - /classic/getting-started/redis/

--- a/_basic/quickstart/getting-started.md
+++ b/_basic/quickstart/getting-started.md
@@ -1,14 +1,15 @@
 ---
 title: Getting Started With Codeship Basic
-weight: 1
 layout: page
+menus:
+  basic/quickstart:
+    title: Getting Started
+    weight: 1
 tags:
   - getting started
   - codeship basic
-
 redirect_from:
   - /basic/getting-started/getting-started/
-
 ---
 
 * include a table of contents

--- a/_basic/services/elasticsearch.md
+++ b/_basic/services/elasticsearch.md
@@ -4,7 +4,10 @@ layout: page
 tags:
   - services
   - elasticsearch
-weight: 1
+menus:
+  basic/services:
+    title: Elasticsearch
+    weight: 1
 redirect_from:
   - /services/elasticsearch/
   - /classic/getting-started/elasticsearch/

--- a/_basic/services/memcached.md
+++ b/_basic/services/memcached.md
@@ -4,7 +4,10 @@ layout: page
 tags:
   - services
   - memcached
-weight: 2
+menus:
+  basic/services:
+    title: Memcached
+    weight: 2
 redirect_from:
   - /services/memcached/
   - /classic/getting-started/memcached/

--- a/_config.yml
+++ b/_config.yml
@@ -25,107 +25,22 @@ defaults:
       weight: 50
       comments: true
       image: /assets/img/og_documentation.jpg
-  - scope:
-      path: "_basic/continuous-deployment"
-    values:
-      category: "Continuous Deployment"
-  - scope:
-      path: "_basic/continuous-integration"
-    values:
-      category: "Continuous Integration"
-  - scope:
-      path: "_basic/quickstart"
-    values:
-      category: "Quickstart"
-  - scope:
-      path: "_basic/languages-frameworks"
-    values:
-      category: "Languages &amp; Frameworks"
-  - scope:
-      path: "_basic/queues"
-    values:
-      category: "Queues"
-  - scope:
-      path: "_basic/services"
-    values:
-      category: "Services"
-  - scope:
-      path: "_basic/databases"
-    values:
-      category: "Databases"
-  - scope:
-      path: "_basic/builds-and-configuration"
-    values:
-      category: "Builds &amp; Configuration"
-  - scope:
-      path: "_pro/continuous-deployment"
-    values:
-      category: "Continuous Deployment"
-  - scope:
-      path: "_pro/continuous-integration"
-    values:
-      category: "Continuous Integration"
-  - scope:
-      path: "_pro/quickstart"
-    values:
-      category: "Quickstart"
-  - scope:
-      path: "_pro/builds-and-configuration"
-    values:
-      category: "Builds &amp; Configuration"
-  - scope:
-      path: "_pro/languages-frameworks"
-    values:
-      category: "Languages &amp; Frameworks"
-  - scope:
-      path: "_general/about"
-    values:
-      category: "About"
-  - scope:
-      path: "_general/account"
-    values:
-      category: "Account"
-  - scope:
-      path: "_general/account/guides"
-    values:
-      category: "Guides"
-  - scope:
-      path: "_general/projects"
-    values:
-      category: "Projects"
-
-sidebar_order:
-  - "Quickstart"
-  - "Builds &amp; Configuration"
-  - "Languages &amp; Frameworks"
-  - "Databases"
-  - "Continuous Deployment"
-  - "Continuous Integration"
-  - "Queues"
-  - "Services"
-  - "About"
-  - "Account"
-  - "Guides"
-  - "Projects"
 
 collections:
   general:
     title: General
     shortname: general
     permalink: /general/:path/
-    sort_order: 1
     output: true
   basic:
     title: Codeship Basic
     shortname: basic
     permalink: /basic/:path/
-    sort_order: 2
     output: true
   pro:
     title: Codeship Pro
     shortname: pro
     permalink: /pro/:path/
-    sort_order: 3
     output: true
 
 # Jekyll
@@ -153,6 +68,7 @@ gems:
   - jekyll-seo-tag
   - jekyll-sitemap
   - jekyll-redirect-from
+  - jekyll-menus
 
 # SASS
 sass:

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -39,6 +39,18 @@ basic:
   - title: Continuous Deployment
     identifier: basic/cd
     url: basic/cd
+  - title: Databases
+    identifier: basic/db
+    url: basic/db
+  - title: Queues
+    identifier: basic/queues
+    url: basic/queues
+  - title: Services
+    identifier: basic/services
+    url: basic/services
+  - title: Languages And Frameworks
+    identifier: basic/languages
+    url: basic/languages
 
 pro:
   - title: Quickstart

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -16,10 +16,12 @@ main:
     url: https://codeship-api.api-docs.io/v1/introduction/auth
 
 general:
-  - title: About
+  - &GENERAL_ABOUT
+    title: About
     identifier: general/about
     url: general/about
-  - title: Account
+  - &GENERAL_ACCOUNT
+    title: Account
     identifier: general/account
     url: general/account
   - title: Projects
@@ -27,6 +29,8 @@ general:
     url: general/projects
 
 basic:
+  - <<: *GENERAL_ABOUT
+  - <<: *GENERAL_ACCOUNT
   - title: Quickstart
     identifier: basic/quickstart
     url: basic/quickstart
@@ -53,6 +57,8 @@ basic:
     url: basic/languages
 
 pro:
+  - <<: *GENERAL_ABOUT
+  - <<: *GENERAL_ACCOUNT
   - title: Quickstart
     identifier: pro/quickstart
     url: pro/quickstart

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -24,19 +24,21 @@ general:
     title: Account
     identifier: general/account
     url: general/account
-  - title: Projects
+  - &GENERAL_PROJECTS
+    title: Projects
     identifier: general/projects
     url: general/projects
 
 basic:
-  - <<: *GENERAL_ABOUT
-  - <<: *GENERAL_ACCOUNT
   - title: Quickstart
     identifier: basic/quickstart
     url: basic/quickstart
   - title: Builds & Configuration
     identifier: basic/builds
     url: basic/builds
+  - title: Languages And Frameworks
+    identifier: basic/languages
+    url: basic/languages
   - title: Continuous Integration
     identifier: basic/ci
     url: basic/ci
@@ -52,28 +54,26 @@ basic:
   - title: Services
     identifier: basic/services
     url: basic/services
-  - title: Languages And Frameworks
-    identifier: basic/languages
-    url: basic/languages
-
-pro:
   - <<: *GENERAL_ABOUT
   - <<: *GENERAL_ACCOUNT
+  - <<: *GENERAL_PROJECTS
+
+pro:
   - title: Quickstart
     identifier: pro/quickstart
     url: pro/quickstart
   - title: Builds & Configuration
     identifier: pro/builds
     url: pro/builds
-  - title: Quickstart
-    identifier: pro/quickstart
-    url: pro/quickstart
-  - title: Continuous Deployment
-    identifier: pro/cd
-    url: pro/cd
-  - title: Continuous Integration
-    identifier: pro/ci
-    url: pro/ci
   - title: Languages And Frameworks
     identifier: pro/languages
     url: pro/languages
+  - title: Continuous Integration
+    identifier: pro/ci
+    url: pro/ci
+  - title: Continuous Deployment
+    identifier: pro/cd
+    url: pro/cd
+  - <<: *GENERAL_ABOUT
+  - <<: *GENERAL_ACCOUNT
+  - <<: *GENERAL_PROJECTS

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -33,6 +33,12 @@ basic:
   - title: Builds & Configuration
     identifier: basic/builds
     url: basic/builds
+  - title: Continuous Integration
+    identifier: basic/ci
+    url: basic/ci
+  - title: Continuous Deployment
+    identifier: basic/cd
+    url: basic/cd
 
 pro:
   - title: Quickstart

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -65,3 +65,15 @@ pro:
   - title: Builds & Configuration
     identifier: pro/builds
     url: pro/builds
+  - title: Quickstart
+    identifier: pro/quickstart
+    url: pro/quickstart
+  - title: Continuous Deployment
+    identifier: pro/cd
+    url: pro/cd
+  - title: Continuous Integration
+    identifier: pro/ci
+    url: pro/ci
+  - title: Languages And Frameworks
+    identifier: pro/languages
+    url: pro/languages

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -1,0 +1,40 @@
+main:
+  - title: Getting Started
+    identifier: getting-started
+    url: /getting-started
+  - title: Basic
+    identifier: basic
+    url: /basic
+  - title: Pro
+    identifier: pro
+    url: /pro
+  - title: More Resources
+    identifier: more-resources
+    url: /more-resources
+  - title: API
+    identifier: api
+    url: https://codeship-api.api-docs.io/v1/introduction/auth
+
+general:
+  - title: About
+    identifier: general/about
+    url: general/about
+  - title: Account
+    identifier: general/account
+    url: general/account
+
+basic:
+  - title: Quickstart
+    identifier: basic/quickstart
+    url: basic/quickstart
+  - title: Builds & Configuration
+    identifier: basic/builds
+    url: basic/builds
+
+pro:
+  - title: Quickstart
+    identifier: pro/quickstart
+    url: pro/quickstart
+  - title: Builds & Configuration
+    identifier: pro/builds
+    url: pro/builds

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -22,6 +22,9 @@ general:
   - title: Account
     identifier: general/account
     url: general/account
+  - title: Projects
+    identifier: general/projects
+    url: general/projects
 
 basic:
   - title: Quickstart

--- a/_general/about/getting_started_with_ci.md
+++ b/_general/about/getting_started_with_ci.md
@@ -1,6 +1,10 @@
 ---
 title: Getting started with Continuous Integration and Continuous Deployment
 layout: page
+menus:
+  general/about:
+    title: Getting Started with CI & CD
+    weight: 1
 tags:
   - faq
   - getting started
@@ -8,10 +12,6 @@ tags:
   - ci
   - cd
   - continuous deployment
-menus:
-  general/about:
-  title: Getting Started With CI/CD
-  weight: 1
 redirect_from:
   - /faq/getting_started_with_ci/
 ---

--- a/_general/about/getting_started_with_ci.md
+++ b/_general/about/getting_started_with_ci.md
@@ -8,7 +8,10 @@ tags:
   - ci
   - cd
   - continuous deployment
-weight: 1
+menus:
+  general/about:
+  title: Getting Started With CI/CD
+  weight: 1
 redirect_from:
   - /faq/getting_started_with_ci/
 ---

--- a/_general/about/git-lfs.md
+++ b/_general/about/git-lfs.md
@@ -4,7 +4,10 @@ layout: page
 tags:
   - git
   - lfs
-weight: 5
+menus:
+  general/about:
+  title: Git LFS
+  weight: 5
 ---
 
 * include a table of contents

--- a/_general/about/git-lfs.md
+++ b/_general/about/git-lfs.md
@@ -1,13 +1,13 @@
 ---
 title: Support For Git LFS Codeship
 layout: page
+menus:
+  general/about:
+    title: GIT LFS
+    weight: 5
 tags:
   - git
   - lfs
-menus:
-  general/about:
-  title: Git LFS
-  weight: 5
 ---
 
 * include a table of contents

--- a/_general/about/mobile-support.md
+++ b/_general/about/mobile-support.md
@@ -1,6 +1,10 @@
 ---
 title: CI/CD For Mobile Apps on Codeship
 layout: page
+menus:
+  general/about:
+    title: CI & CD for mobile
+    weight: 4
 tags:
   - mobile
   - osx
@@ -8,10 +12,6 @@ tags:
   - ios
   - swift
   - objective-c
-menus:
-  general/about:
-  title: Mobile Support
-  weight: 5
 ---
 
 * include a table of contents

--- a/_general/about/mobile-support.md
+++ b/_general/about/mobile-support.md
@@ -8,7 +8,10 @@ tags:
   - ios
   - swift
   - objective-c
-weight: 4
+menus:
+  general/about:
+  title: Mobile Support
+  weight: 5
 ---
 
 * include a table of contents

--- a/_general/about/permissions.md
+++ b/_general/about/permissions.md
@@ -14,7 +14,10 @@ redirect_from:
   - /faq/github-3rd-party-restrictions/
   - /general/account/github-3rd-party-restrictions/
   - /general/account/permissions/
-weight: 4
+menus:
+  general/about:
+  title: Permissions & Access
+  weight: 4
 ---
 
 * include a table of contents

--- a/_general/about/permissions.md
+++ b/_general/about/permissions.md
@@ -1,7 +1,10 @@
 ---
 title: Repository Permissions and Access On Codeship
 layout: page
-weight: 27
+menus:
+  general/about:
+    title: Required Permissions for Remote SCMs
+    weight: 4
 tags:
   - security
   - permissions
@@ -14,10 +17,6 @@ redirect_from:
   - /faq/github-3rd-party-restrictions/
   - /general/account/github-3rd-party-restrictions/
   - /general/account/permissions/
-menus:
-  general/about:
-  title: Permissions & Access
-  weight: 4
 ---
 
 * include a table of contents

--- a/_general/about/security.md
+++ b/_general/about/security.md
@@ -1,15 +1,15 @@
 ---
 title: Security Information For CI/CD Infrastructure
 layout: page
+menus:
+  general/about:
+    title: Security Information
+    weight: 3
 tags:
   - security
   - gpg key
   - permissions
   - ssh
-menus:
-  general/about:
-  title: Security Information
-  weight: 3
 redirect_from:
   - /security/
   - /security/security/

--- a/_general/about/security.md
+++ b/_general/about/security.md
@@ -6,7 +6,10 @@ tags:
   - gpg key
   - permissions
   - ssh
-weight: 3
+menus:
+  general/about:
+  title: Security Information
+  weight: 3
 redirect_from:
   - /security/
   - /security/security/

--- a/_general/about/vm-and-infrastructure.md
+++ b/_general/about/vm-and-infrastructure.md
@@ -1,15 +1,15 @@
 ---
 title: VM And Infrastructure Specifics
 layout: page
+menus:
+  general/about:
+    title: VM & Infrastructure Specifics
+    weight: 2
 tags:
   - security
   - infrastructure
   - linux
   - firewall
-menus:
-  general/about:
-  title: VM & Machine Information
-  weight: 2
 redirect_from:
   - /security/vm-and-infrastructure/
 ---
@@ -31,11 +31,11 @@ All Codeship Pro builds run on dedicated, single tenant build machines, on indiv
 
 The Codeship Pro build environment is configurable depending on plan and available in the following configurations:
 
-- **Small**: 2 CPUs, 3.75gb RAM
-- **Medium**: 4 CPUs, 7.5gb RAM
-- **Big**: 8 CPUs, 15gb RAM
-- **Huge**: 16 CPUs, 30gb RAM
-- **Massive**: 32 CPUs, 60gb RAM
+**Small**: 2 CPUs, 3.75gb RAM
+**Medium**: 4 CPUs, 7.5gb RAM
+**Big**: 8 CPUs, 15gb RAM
+**Huge**: 16 CPUs, 30gb RAM
+**Massive**: 32 CPUs, 60gb RAM
 
 ### Docker Version On Codeship Pro
 

--- a/_general/about/vm-and-infrastructure.md
+++ b/_general/about/vm-and-infrastructure.md
@@ -6,7 +6,10 @@ tags:
   - infrastructure
   - linux
   - firewall
-weight: 2
+menus:
+  general/about:
+  title: VM & Machine Information
+  weight: 2
 redirect_from:
   - /security/vm-and-infrastructure/
 ---

--- a/_general/account/cancel.md
+++ b/_general/account/cancel.md
@@ -1,6 +1,9 @@
 ---
 title: How To Cancel Or Delete Your Account
-weight: 11
+menus:
+  general/account:
+    title: Cancelling Account
+    weight: 5
 tags:
 - cancel
 - account

--- a/_general/account/guides/migrating-from-jenkins-notifications.md
+++ b/_general/account/guides/migrating-from-jenkins-notifications.md
@@ -1,6 +1,9 @@
 ---
 title: Migrating From Jenkins To Codeship - Notifications
-weight: 2
+menus:
+  general/account:
+    title: Jenkins To Codeship - Notifications
+    weight: 7
 tags:
   - jenkins
   - notifications

--- a/_general/account/guides/migrating-from-jenkins-organizations.md
+++ b/_general/account/guides/migrating-from-jenkins-organizations.md
@@ -1,6 +1,9 @@
 ---
 title: Migrating From Jenkins To Codeship - Organizations
-weight: 1
+menus:
+  general/account:
+    title: Jenkins to Codeship - Teams
+    weight: 6
 tags:
   - jenkins
   - organizations

--- a/_general/account/guides/migrating-from-jenkins-testing.md
+++ b/_general/account/guides/migrating-from-jenkins-testing.md
@@ -1,6 +1,9 @@
 ---
 title: Migrating From Jenkins To Codeship - Testing
-weight: 3
+menus:
+  general/account:
+    title: Jenkins To Codeship - Testing
+    weight: 8
 tags:
   - jenkins
   - testing

--- a/_general/account/invoices.md
+++ b/_general/account/invoices.md
@@ -6,7 +6,10 @@ tags:
   - account
   - invoices
   - billing
-weight: 5
+menus:
+  general/account:
+    title: Invoices
+    weight: 4
 redirect_from:
   - /administration/invoices/
 ---

--- a/_general/account/new-user-signup.md
+++ b/_general/account/new-user-signup.md
@@ -1,6 +1,9 @@
 ---
 title: Signing Up For A New Codeship Account
-weight: 10
+menus:
+  general/account:
+    title: New User Signup
+    weight: 1
 tags:
 - account
 - faq
@@ -16,7 +19,7 @@ redirect_from:
   - /faq/codeship-badge/
   - /general/about/codeship-badge/
   - /faq/configure-your-avatar/
-  - /faq/other-scm/  
+  - /faq/other-scm/
 weight: 1
 ---
 
@@ -65,7 +68,7 @@ Once you’ve signed-up for Codeship you’ll be directed to a short form where 
 
 Simply click on the SCM icon you would like to connect with and proceed to provide your login credentials in order to give Codeship access to your account (see step 1 for further information).
 
-**Choose your repository:** Once you have authenticated your SCM you have to select your repository.  To choose your repository, simply paste your Git clone URL into the provided area and click ‘Connect’.  
+**Choose your repository:** Once you have authenticated your SCM you have to select your repository.  To choose your repository, simply paste your Git clone URL into the provided area and click ‘Connect’.
 
 _Examples_:
 - git@gitlab.com:<username>/<repository_name>.git

--- a/_general/account/notifications.md
+++ b/_general/account/notifications.md
@@ -9,7 +9,10 @@ redirect_from:
   - /administration/notifications/
   - /basic/getting-started/webhooks/
   - /integrations/webhooks/
-weight: 2
+menus:
+  general/account:
+    title: Notifications
+    weight: 3
 ---
 
 * include a table of contents

--- a/_general/account/organizations.md
+++ b/_general/account/organizations.md
@@ -10,7 +10,10 @@ tags:
 
 redirect_from:
   - /administration/organizations/
-weight: 3  
+menus:
+  general/account:
+    title: Organization Accounts
+    weight: 2
 ---
 
 * include a table of contents

--- a/_general/projects/access-to-other-repositories-fails-during-build.md
+++ b/_general/projects/access-to-other-repositories-fails-during-build.md
@@ -1,7 +1,10 @@
 ---
 title: Cloning other repositories fails during build
 layout: page
-weight: 5
+menus:
+  general/projects:
+    title: Accessing Other Repos
+    weight: 3
 tags:
   - faq
   - build error

--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -1,7 +1,10 @@
 ---
 title: Troubleshooting Issues With Builds Not Starting
 layout: page
-weight: 4
+menus:
+  general/projects:
+    title: Builds Not Starting
+    weight: 6
 tags:
   - troubleshooting
   - build error

--- a/_general/projects/getting-started.md
+++ b/_general/projects/getting-started.md
@@ -1,6 +1,9 @@
 ---
 title: Getting Started With Projects
-weight: 1
+menus:
+  general/projects:
+    title: Creating New Projects
+    weight: 1
 layout: page
 tags:
   - administration

--- a/_general/projects/pending-step-in-cucumber-fails-build.md
+++ b/_general/projects/pending-step-in-cucumber-fails-build.md
@@ -1,7 +1,10 @@
 ---
 title: Troubleshooting Cucumber Failures In CI/CD with Codeship Basic
 layout: page
-weight: 7
+menus:
+  general/projects:
+    title: Cucumber Failures
+    weight: 7
 tags:
   - troubleshooting
   - build error

--- a/_general/projects/project-ssh-key.md
+++ b/_general/projects/project-ssh-key.md
@@ -1,6 +1,9 @@
 ---
 title: Project SSH Public Key
-weight: 2
+menus:
+  general/projects:
+    title: SSH Public Key
+    weight: 2
 tags:
   - project settings
   - ssh key

--- a/_general/projects/push-to-remote-repositories.md
+++ b/_general/projects/push-to-remote-repositories.md
@@ -1,7 +1,10 @@
 ---
 title: Pushing to git remote fails
 layout: page
-weight: 6
+menus:
+  general/projects:
+    title: Git Remote Push
+    weight: 5
 tags:
   - troubleshooting
   - build error

--- a/_general/projects/skipping-builds.md
+++ b/_general/projects/skipping-builds.md
@@ -1,6 +1,9 @@
 ---
 title: Skipping builds
-weight: 3
+menus:
+  general/projects:
+    title: Skipping Builds
+    weight: 4
 tags:
   - docker
   - basic

--- a/_includes/documentation_header.html
+++ b/_includes/documentation_header.html
@@ -2,36 +2,11 @@
 <nav class="Topmenu">
   <div class="collg50">
     <div class="Topmenu_nav">
-      <ul>
-        <li>
-          {% if page.active == "gettingstarted" %}
-          <a href="/getting-started" class="active">Getting Started</a>
-         {% else %}
-            <a href="/getting-started">Getting Started</a>
-         {% endif %}      </li>
-        <li>
-          {% if page.active == "pro" or page.collection == "pro" %}
-          <a href="/pro" class="active">Pro</a>
-         {% else %}
-            <a href="/pro">Pro</a>
-         {% endif %}      </li>
-        <li>
-          {% if page.active == "basic" or page.collection == "basic" %}
-          <a href="/basic" class="active">Basic</a>
-         {% else %}
-            <a href="/basic">Basic</a>
-         {% endif %}      </li>
-        <li>
-          {% if page.active == "moreresources" %}
-          <a href="/more-resources" class="active">More Resources</a>
-         {% else %}
-            <a href="/more-resources">More Resources</a>
-         {% endif %}
-        </li>
-        <li>
-            <a href="https://codeship-api.api-docs.io/v1/introduction/auth">API</a>
-        </li>
-      </ul>
+			<ul>
+				{% for item in site.menus.main %}
+        <li><a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a></li>
+      	{% endfor %}
+			</ul>
     </div>
   </div>
   <div class="collg50">

--- a/_includes/documentation_header.html
+++ b/_includes/documentation_header.html
@@ -1,29 +1,29 @@
 {% assign collections = site.collections | sort: 'sort_order' %}
 <nav class="Topmenu">
-  <div class="collg50">
-    <div class="Topmenu_nav">
+	<div class="collg50">
+		<div class="Topmenu_nav">
 			<ul>
 				{% for item in site.menus.main %}
-        <li><a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a></li>
-      	{% endfor %}
+					<li><a href="{{ item.url | prepend: site.baseurl }}" {% if item.identifier == page.collection %} class="active" {% endif %}>{{ item.title }}</a></li>
+				{% endfor %}
 			</ul>
-    </div>
-  </div>
-  <div class="collg50">
-    <div class="Topmenu_search">
-      <form action="/">
-        <input type="search" id="search" name="search" autofocus="false" spellcheck="false" placeholder="Search the documentation">
-        <input class="is-hidden" type="submit" />
-      </form>
-    </div>
-  </div>
+		</div>
+	</div>
+	<div class="collg50">
+		<div class="Topmenu_search">
+			<form action="/">
+				<input type="search" id="search" name="search" autofocus="false" spellcheck="false" placeholder="Search the documentation">
+				<input class="is-hidden" type="submit" />
+			</form>
+		</div>
+	</div>
 </nav>
 
 <script type="text/javascript">
-  (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
-  (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-  e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
-  })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
+	(function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+	(w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+	e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+	})(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
 
-  _st('install','bkVUpGdrMMVM73Lx7EQp');
+	_st('install','bkVUpGdrMMVM73Lx7EQp');
 </script>

--- a/_includes/menus.html
+++ b/_includes/menus.html
@@ -1,8 +1,11 @@
+{% for menu in page.menus %}
+	{% assign category = menu[0] %}
+{% endfor %}
 <ul {% if include.toplevel %} class="ul" {% endif %}>
   {% for item in include.menu %}
 		{% if include.toplevel %}
 		<li class="ul__title">
-			<input type="checkbox" {% if unfold %} checked {% endif %}>
+			<input type="checkbox" {% if category == item.identifier %} checked {% endif %}>
 			<i></i>
 			<h5 class="title">{{ item.title }}</h5>
 		{% else %}

--- a/_includes/menus.html
+++ b/_includes/menus.html
@@ -1,0 +1,17 @@
+<ul {% if include.toplevel %} class="ul" {% endif %}>
+  {% for item in include.menu %}
+		{% if include.toplevel %}
+		<li class="ul__title">
+			<input type="checkbox" {% if unfold %} checked {% endif %}>
+			<i></i>
+			<h5 class="title">{{ item.title }}</h5>
+		{% else %}
+		<li>
+			<a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
+		{% endif %}
+    {% if item.children %}
+      {% include menus.html menu=item.children%}
+    {% endif %}
+		</li>
+  {% endfor %}
+</ul>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,30 +1,11 @@
-{% assign c = site.collections | where: 'label', page.collection | first %}
-{% assign g = site.collections | where: 'label', 'general' | first %}
-{% assign c = c.docs | group_by: 'category' %}
-{% assign g = g.docs | group_by: 'category' %}
-{% assign collection = c | concat: g  %}
-{% assign categories = collection %}
-
 <aside class="Sidebar">
-  <ul class="ul">
-    {% for category in site.sidebar_order %}
-      {% assign current = categories | where:"name", category | first %}
-      {% assign documents = current.items %}
-      {% unless documents == nil %}
-      <li class="ul__title">
-        <input type="checkbox" {% if page.category == current.name %}checked{% endif %}>
-        <i></i>
-        <h5 class="title">{{ current.name }}</h5>
-        <ul>
-          {% assign documents = documents | sort:"weight" %}
-          {% for document in documents %}
-            <li>
-              <a href="{{ document.url | relative_url }}">{{ document.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
-      {% endunless %}
-    {% endfor %}
-  </ul>
+	{% case page.collection %}
+		{% when 'basic'%}
+			{% assign menu=site.menus.basic %}
+		{% when 'pro' %}
+			{% assign menu=site.menus.pro %}
+		{% when 'general' %}
+			{% assign menu=site.menus.general %}
+	{% endcase %}
+	{% include menus.html menu=menu toplevel=true %}
 </aside>

--- a/_pro/builds-and-configuration/build-arguments.md
+++ b/_pro/builds-and-configuration/build-arguments.md
@@ -1,7 +1,10 @@
 ---
 title: Using Docker Build Arguments In CI/CD
 layout: page
-weight: 7
+menus:
+  pro/builds:
+    title: Build Arguments
+    weight: 7
 tags:
   - docker
   - tutorial

--- a/_pro/builds-and-configuration/caching.md
+++ b/_pro/builds-and-configuration/caching.md
@@ -1,7 +1,10 @@
 ---
 title: Speed Up Your Builds With Caching on Codeship Pro
 layout: page
-weight: 6
+menus:
+  pro/builds:
+    title: Image Caching
+    weight: 6
 tags:
   - docker
   - tutorial

--- a/_pro/builds-and-configuration/cli.md
+++ b/_pro/builds-and-configuration/cli.md
@@ -1,7 +1,10 @@
 ---
 title: Debugging And Setup With The Codeship Local CLI (Codeship Pro)
 layout: page
-weight: 1
+menus:
+  pro/builds:
+    title: Local CLI
+    weight: 1
 tags:
   - docker
   - jet

--- a/_pro/builds-and-configuration/cloning-repos.md
+++ b/_pro/builds-and-configuration/cloning-repos.md
@@ -1,7 +1,10 @@
 ---
 title: Using Multiple Repositories
 layout: page
-weight: 11
+menus:
+  pro/builds:
+    title: Multiple Repos
+    weight: 11
 tags:
   - docker
   - tutorial

--- a/_pro/builds-and-configuration/docker-volumes.md
+++ b/_pro/builds-and-configuration/docker-volumes.md
@@ -1,7 +1,10 @@
 ---
 title: Using Docker Volumes In CI/CD
 layout: page
-weight: 8
+menus:
+  pro/builds:
+    title: Volumes
+    weight: 8
 tags:
   - docker
   - tutorial

--- a/_pro/builds-and-configuration/environment-variables.md
+++ b/_pro/builds-and-configuration/environment-variables.md
@@ -1,7 +1,10 @@
 ---
 title: Environment Variables On Codeship Pro
 layout: page
-weight: 4
+menus:
+  pro/builds:
+    title: Environment Variables
+    weight: 4
 tags:
   - docker
   - encryption

--- a/_pro/builds-and-configuration/handling-secrets.md
+++ b/_pro/builds-and-configuration/handling-secrets.md
@@ -1,7 +1,10 @@
 ---
 title: Handling Secrets With Docker And Codeship Pro
 layout: page
-weight: 10
+menus:
+  pro/builds:
+    title: Handling Secrets
+    weight: 10
 tags:
   - docker
   - secrets

--- a/_pro/builds-and-configuration/image-registries.md
+++ b/_pro/builds-and-configuration/image-registries.md
@@ -1,7 +1,10 @@
 ---
 title: Using Docker Image Registries With Your CI/CD Builds
 layout: page
-weight: 5
+menus:
+  pro/builds:
+    title: Image Registries
+    weight: 5
 tags:
   - docker
   - tutorial

--- a/_pro/builds-and-configuration/release-notes.md
+++ b/_pro/builds-and-configuration/release-notes.md
@@ -1,7 +1,10 @@
 ---
 title: CLI Release Notes
 layout: page
-weight: 13
+menus:
+  pro/builds:
+    title: CLI Release Notes
+    weight: 13
 tags:
   - docker
   - jet

--- a/_pro/builds-and-configuration/services-and-databases.md
+++ b/_pro/builds-and-configuration/services-and-databases.md
@@ -1,7 +1,10 @@
 ---
 title: Supported Services and Databases
 layout: page
-weight: 12
+menus:
+  pro/builds:
+    title: Services And Databases
+    weight: 12
 tags:
   - docker
   - jet

--- a/_pro/builds-and-configuration/services.md
+++ b/_pro/builds-and-configuration/services.md
@@ -1,7 +1,10 @@
 ---
 title: Services Configuration
 layout: page
-weight: 2
+menus:
+  pro/builds:
+    title: Services Config
+    weight: 2
 tags:
   - docker
   - jet

--- a/_pro/builds-and-configuration/steps.md
+++ b/_pro/builds-and-configuration/steps.md
@@ -1,7 +1,10 @@
 ---
 title: Steps Configuration
 layout: page
-weight: 3
+menus:
+  pro/builds:
+    title: Steps Config
+    weight: 3
 tags:
   - docker
   - jet

--- a/_pro/continuous-deployment/aws.md
+++ b/_pro/continuous-deployment/aws.md
@@ -1,6 +1,9 @@
 ---
 title: Continuous Delivery to AWS with Docker
-weight: 1
+menus:
+  pro/cd:
+    title: AWS
+    weight: 1
 tags:
   - deployment
   - aws

--- a/_pro/continuous-deployment/azure.md
+++ b/_pro/continuous-deployment/azure.md
@@ -1,6 +1,9 @@
 ---
 title: Continuous Delivery to Microsoft Azure with Docker
-weight: 2
+menus:
+  pro/cd:
+    title: Azure
+    weight: 2
 tags:
   - deployment
   - azure

--- a/_pro/continuous-deployment/deployment-with-kubernetes.md
+++ b/_pro/continuous-deployment/deployment-with-kubernetes.md
@@ -1,6 +1,9 @@
 ---
 title: Continuous Deployment With Docker, Kubernetes And Codeship Pro
-weight: 1
+menus:
+  pro/cd:
+    title: Kubernetes
+    weight: 5
 tags:
   - kubernetes
   - notifications

--- a/_pro/continuous-deployment/google-cloud.md
+++ b/_pro/continuous-deployment/google-cloud.md
@@ -1,6 +1,9 @@
 ---
 title: Continuous Delivery to Google Cloud Platform with Docker
-weight: 3
+menus:
+  pro/cd:
+    title: Google Cloud
+    weight: 4
 tags:
   - deployment
   - heroku

--- a/_pro/continuous-deployment/heroku.md
+++ b/_pro/continuous-deployment/heroku.md
@@ -1,6 +1,9 @@
 ---
 title: Continuous Delivery to Heroku with Docker
-weight: 4
+menus:
+  pro/cd:
+    title: Heroku
+    weight: 3
 tags:
   - deployment
   - heroku

--- a/_pro/continuous-deployment/rollbar-docker.md
+++ b/_pro/continuous-deployment/rollbar-docker.md
@@ -1,7 +1,10 @@
 ---
 title: Using Rollbar To Track Deployments With Codeship Pro
 layout: page
-weight: 6
+menus:
+  pro/cd:
+    title: Using Rollbar
+    weight: 7
 tags:
   - rollbar
   - deployment

--- a/_pro/continuous-deployment/ssh-deploy.md
+++ b/_pro/continuous-deployment/ssh-deploy.md
@@ -1,7 +1,10 @@
 ---
 title: Continuous Delivery Via SSH With Docker
 layout: page
-weight: 5
+menus:
+  pro/cd:
+    title: Deploy Via SSH
+    weight: 6
 tags:
   - docker
   - deployment

--- a/_pro/continuous-integration/browser-testing.md
+++ b/_pro/continuous-integration/browser-testing.md
@@ -1,7 +1,10 @@
 ---
 title: Browser Testing During CI/CD With Codeship Pro
 layout: page
-weight: 2
+menus:
+  pro/ci:
+    title: Browser Testing
+    weight: 2
 tags:
   - docker
   - jet

--- a/_pro/continuous-integration/parallel-pro.md
+++ b/_pro/continuous-integration/parallel-pro.md
@@ -1,7 +1,10 @@
 ---
 title: Speed Up Your Builds With Parallel Testing on Codeship Pro
 layout: page
-weight: 1
+menus:
+  pro/ci:
+    title: Parallel Testing
+    weight: 1
 tags:
   - docker
   - jet

--- a/_pro/continuous-integration/percy-docker.md
+++ b/_pro/continuous-integration/percy-docker.md
@@ -4,7 +4,10 @@ layout: page
 tags:
   - screenshots
   - visual testing
-weight: 3
+menus:
+  pro/ci:
+    title: Using Percy
+    weight: 3
 ---
 
 * include a table of contents

--- a/_pro/languages-frameworks/go.md
+++ b/_pro/languages-frameworks/go.md
@@ -1,6 +1,9 @@
 ---
 title: Using Go In CI/CD with Docker and Codeship Pro
-weight: 4
+menus:
+  pro/languages:
+    title: Go
+    weight: 4
 tags:
   - go
   - languages

--- a/_pro/languages-frameworks/java.md
+++ b/_pro/languages-frameworks/java.md
@@ -1,6 +1,9 @@
 ---
 title: Using Java In CI/CD with Docker and Codeship Pro
-weight: 5
+menus:
+  pro/languages:
+    title: Java And JVM
+    weight: 5
 tags:
   - java
   - languages

--- a/_pro/languages-frameworks/nodejs.md
+++ b/_pro/languages-frameworks/nodejs.md
@@ -1,6 +1,9 @@
 ---
 title: Using Node.js In CI/CD with Docker and Codeship Pro
-weight: 3
+menus:
+  pro/languages:
+    title: Node.js
+    weight: 3
 tags:
   - node.js
   - languages

--- a/_pro/languages-frameworks/php.md
+++ b/_pro/languages-frameworks/php.md
@@ -1,6 +1,9 @@
 ---
 title: Using PHP In CI/CD with Docker and Codeship Pro
-weight: 6
+menus:
+  pro/languages:
+    title: PHP
+    weight: 6
 tags:
   - php
   - languages

--- a/_pro/languages-frameworks/python.md
+++ b/_pro/languages-frameworks/python.md
@@ -1,6 +1,9 @@
 ---
 title: Using Python In CI/CD with Docker and Codeship Pro
-weight: 2
+menus:
+  pro/languages:
+    title: Python
+    weight: 2
 tags:
   - python
   - languages

--- a/_pro/languages-frameworks/ruby.md
+++ b/_pro/languages-frameworks/ruby.md
@@ -1,6 +1,9 @@
 ---
 title: Using Ruby In CI/CD with Docker and Codeship Pro
-weight: 1
+menus:
+  pro/languages:
+    title: Ruby
+    weight: 1
 tags:
   - ruby
   - languages

--- a/_pro/quickstart/codeship-configuration.md
+++ b/_pro/quickstart/codeship-configuration.md
@@ -1,7 +1,10 @@
 ---
 title: Setting Up Or Migrating A Project To Codeship Pro
 layout: page
-weight: 6
+menus:
+  pro/quickstart:
+    title: Migrating To Pro
+    weight: 6
 tags:
   - docker
   - jet

--- a/_pro/quickstart/getting-started-part-five.md
+++ b/_pro/quickstart/getting-started-part-five.md
@@ -1,7 +1,10 @@
 ---
 title: Getting Started With Codeship Pro Part 5
 layout: page
-weight: 5
+menus:
+  pro/quickstart:
+    title: Getting Started Pt. 5
+    weight: 5
 tags:
   - docker
   - jet

--- a/_pro/quickstart/getting-started-part-four.md
+++ b/_pro/quickstart/getting-started-part-four.md
@@ -1,7 +1,10 @@
 ---
 title: Getting Started With Codeship Pro Part 4
 layout: page
-weight: 4
+menus:
+  pro/quickstart:
+    title: Getting Started Pt. 4
+    weight: 4
 tags:
   - docker
   - jet

--- a/_pro/quickstart/getting-started-part-three.md
+++ b/_pro/quickstart/getting-started-part-three.md
@@ -1,7 +1,10 @@
 ---
 title: Getting Started With Codeship Pro Part 3
 layout: page
-weight: 3
+menus:
+  pro/quickstart:
+    title: Getting Started Pt. 3
+    weight: 3
 tags:
   - docker
   - jet

--- a/_pro/quickstart/getting-started-part-two.md
+++ b/_pro/quickstart/getting-started-part-two.md
@@ -1,7 +1,10 @@
 ---
 title: Getting Started With Codeship Pro Part 2
 layout: page
-weight: 2
+menus:
+  pro/quickstart:
+    title: Getting Started Pt. 2
+    weight: 2
 tags:
   - docker
   - jet

--- a/_pro/quickstart/getting-started.md
+++ b/_pro/quickstart/getting-started.md
@@ -1,7 +1,10 @@
 ---
 title: Getting Started With Codeship Pro Part 1
 layout: page
-weight: 1
+menus:
+  pro/quickstart:
+    title: Getting Started Pt. 1
+    weight: 1
 tags:
   - docker
   - jet

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -2,7 +2,7 @@
 layout: default
 title: Documentation
 bodyclass: is-blue
-active: gettingstarted
+active: getting-started
 ---
 {% assign collections = site.collections | sort: 'sort_order' %}
 

--- a/more-resources/index.html
+++ b/more-resources/index.html
@@ -2,7 +2,7 @@
 title: More Resources For CI/CD With Codeship
 layout: default
 bodyclass: is-blue
-active: moreresources
+active: more-resources
 ---
 <div class="contentWrapper">
   <div class="grid">


### PR DESCRIPTION
This is a rewrite of the sidebar and top navigation menus based on https://github.com/forestryio/jekyll-menus

It reuses the same HTML and CSS, but allows for flexible categories based on the collection, as well as adding the same article to multiple menus. It supports weighing and different titles in the menus out of the box.

What's currently not working:

* [x] Highlighting the active collection in the top navigation
* [x] Expanding the active section in the sidebar
* [x] Merging the sub items of the _General_ category into _Basic_ and _Pro_ categories
* ... (I probably missed something)

@ethangj let me know what you think and if we should continue.