### PR TITLE
removed stated support for node, added emphasis to supported languages

### DIFF
--- a/_basic/continuous-deployment/deployment-to-google-app-engine.md
+++ b/_basic/continuous-deployment/deployment-to-google-app-engine.md
@@ -14,7 +14,7 @@ redirect_from:
   - /tutorials/continuous-deployment-google-app-engine-github-django-python/
 ---
 
-**Please note:** Codeship currently supports Google App Engine deployments for the following environments: [Java]({{ site.baseurl }}{% link _basic/languages-frameworks/java-and-jvm-based-languages.md %}),[Python]({{ site.baseurl }}{% link _basic/languages-frameworks/python.md %}), and [Go]({{ site.baseurl }}{% link _basic/languages-frameworks/go.md %}).
+**Please note:** Codeship Basic currently runs Google App Engine SDK version `1.9.40` and supports the following languages: [Java]({{ site.baseurl }}{% link _basic/languages-frameworks/java-and-jvm-based-languages.md %}),[Python]({{ site.baseurl }}{% link _basic/languages-frameworks/python.md %}) and [Go]({{ site.baseurl }}{% link _basic/languages-frameworks/go.md %}).
 
 * include a table of contents
 {:toc}

--- a/_basic/continuous-deployment/deployment-to-google-app-engine.md
+++ b/_basic/continuous-deployment/deployment-to-google-app-engine.md
@@ -14,10 +14,10 @@ redirect_from:
   - /tutorials/continuous-deployment-google-app-engine-github-django-python/
 ---
 
+**Please note:** Codeship currently supports Google App Engine deployments for the following environments: [Java]({{ site.baseurl }}{% link _basic/languages-frameworks/java-and-jvm-based-languages.md %}),[Python]({{ site.baseurl }}{% link _basic/languages-frameworks/python.md %}), and [Go]({{ site.baseurl }}{% link _basic/languages-frameworks/go.md %}).
+
 * include a table of contents
 {:toc}
-
-You can deploy your [Java]({{ site.baseurl }}{% link _basic/languages-frameworks/java-and-jvm-based-languages.md %}),[Python]({{ site.baseurl }}{% link _basic/languages-frameworks/python.md %}), [NodeJS]({{ site.baseurl }}{% link _basic/languages-frameworks/nodejs.md  %}) , or [Go]({{ site.baseurl }}{% link _basic/languages-frameworks/go.md %}) applications to Google App Engine through Codeship.
 
 ## Setup Google App Engine Deployment
 
@@ -55,7 +55,7 @@ Once connected, you will be brought back to your Google App Engine deployment se
 
 You can set the path of your `appcfg.*` file in the _Update Path:_ field. If the file exists on the root of your repository, simply leave it blank.
 
-By default we search for a `app.yml` file in the path you've set. If we find it we will use the `appcfg.py` script to upload your application. Otherwise we expect it to be a Java application and use `appcfg.sh`.
+By default we search for a `app.yml` file in the path you've set. If we find it we will use the `appcfg.py` script to upload your application. If the `app.yml` file is not located, we'll presume the application to be Java based and will use the `appcfg.sh` script insteaad.
 
 #### Application URL
 


### PR DESCRIPTION
[Community discussion](https://community.codeship.com/t/how-to-deploy-node-js-with-appengine/4112/14) acknowledged our lack of support for node.js with google app engine.

Discussion as well on a [pivotal tracker ticket](https://www.pivotaltracker.com/story/show/146398621) regarding the need for an overhaul.

So at the very least, I've gone ahead with removing our stated support of node.js as well as edited a line for clarification.