### PR TITLE
Fix cc-test-reporter after command

### DIFF
--- a/_general/integrations/codeclimate.md
+++ b/_general/integrations/codeclimate.md
@@ -62,7 +62,7 @@ After your final test commands:
 ```bash
 - name: codeclimate_post
   service: YOURSERVICE
-  command: cc-test-reporter after-build --exit-code $
+  command: cc-test-reporter after-build --exit-code $?
 ```
 
 ### Parallel Test Coverage
@@ -139,7 +139,7 @@ cc-test-reporter before-build
 After your final tests have run:
 
 ```bash
-cc-test-reporter after-build --exit-code $
+cc-test-reporter after-build --exit-code $?
 ```
 
 ### Parallel Test Coverage


### PR DESCRIPTION
Copy/pasting the `cc-test-reporter` after command into Test Steps resulted in the build failing as `$` returns an error where as `$?` returns the last pid exit code.