### PR TITLE
Google App Engine deployment instructions for Codeship Pro

### DIFF
--- a/_pro/continuous-deployment/google-app-engine.md
+++ b/_pro/continuous-deployment/google-app-engine.md
@@ -18,15 +18,27 @@ tags:
 
 ## Deploying To Google App Engine
 
-Follow these steps to deploy your application to [Google App Engine](https://cloud.google.com/appengine/).
+To deploy to [Google App Engine](https://cloud.google.com/appengine/), you will need to create a container that can authenticate with your Google Account, and with the appropriate Google product, as well as run the Google Cloud CLI to execute your intended commands.
 
-### Authentication
+We maintain an [example repository](https://github.com/codeship-library/google-cloud-deployment) with [an image stored on Dockerhub](https://hub.docker.com/r/codeship/google-cloud-deployment/) to simplify this process. You can copy setup instructions from this repo or reuse the Dockerfile, our [turnkey Google Cloud image](https://hub.docker.com/r/codeship/google-cloud-deployment/) or our [GCR authentication generator](https://hub.docker.com/r/codeship/gcr-dockercfg-generator/) simply by adding the necessary elements from our [Google Cloud repo](https://github.com/codeship-library/google-cloud-deployment) to your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}).
 
-Deploying your application to App Engine via the `gcloud` utility only involves a couple of commands. Please follow the steps for [creating a Google Cloud service account](#authentication) and encrypting the provided credentials. Those are required to authenticate with Google Cloud during the deployment phase.
+## Authentication
 
-### Deployment Service
+To deploy to App Engine, you will need to define a Google _Service account_ as well as add your Googel credentials to your [encrypted environment variables]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}) so that the `gcloud` utility can authenticate approriately.
 
-You will want to add a service which references the [Google Cloud deployment image]((https://hub.docker.com/r/codeship/google-cloud-deployment/), which is maintained by Codeship, in your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}). For example:
+For full instructions, see the [authentication portion of our Google Cloud documentation]({{ site.baseurl }}{% link _pro/continuous-deployment/google-cloud.md %}#authentication).
+
+### Codeship Public Key
+
+Some Google Cloud services will require that you add your [Codeship public key]({{ site.baseurl }}{% link _general/projects/project-ssh-key.md %}) for authentication purposes.
+
+**Note** that Google may fail authentication if you do not add the Google Cloud user the key is for to the end of the key. For example, if the Google Cloud user is `deploy@Codeship`, you will want to add `deploy@Codeship` to the end of the SSH key itself, otherwise Google will not load the key for the user appropriately.
+
+## Commands And Deployments
+
+### Creating Your Services
+
+You will want to add a service which builds the [Google Cloud deployment image]((https://hub.docker.com/r/codeship/google-cloud-deployment/), which is maintained by Codeship, in your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}). For example:
 
 ```yaml
 googleclouddeployment:
@@ -39,9 +51,11 @@ googleclouddeployment:
 
 **Note** that this example adds your Google Cloud account credentials as encrypted environment variables and mounts the repository as a [volume]({{ site.baseurl }}{% link _pro/builds-and-configuration/docker-volumes.md %}) to the `/deploy` folder inside the container so that it is usable as part of the build.
 
-### Deployment Step
+### Deployment Commands
 
-Add the following snippet to your `codeship-steps.yml` file, referencing the service we added earlier and calling a `google-deploy.sh` script which will deploy your application to Google App Engine.
+After defining your authentication variables and your deployment service, you will want to run deployment commands via your [codeship-steps.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}).
+
+Because each step runs in a separate group of containers, you will likely want to bundle you Google Cloud commands together in a script file that you add to your repository and call from a step:
 
 ```yaml
 - name: google-cloud-deployment
@@ -49,7 +63,9 @@ Add the following snippet to your `codeship-steps.yml` file, referencing the ser
   command: google-deploy.sh
 ```
 
-Following is a very basic version of an App Engine deployment script. You can customize the script to fit your specific needs, e.g. by specifying custom configuration files that will drive the deployment instead of the default `app.yml`. Save this script as `google-deploy.sh` to the root of your repository.
+Inside this deployment script will be all commands you want to run via the Google Cloud or Kubernetes CLI, both included in the [deployment image that we maintain]((https://hub.docker.com/r/codeship/google-cloud-deployment/).
+
+Here is an example deployment script that you can use as a basis for your own deployments. Note that it authenticates at the top using the command discussed earlier.
 
 ```bash
 #!/bin/bash
@@ -65,6 +81,6 @@ cd /deploy/
 gcloud app deploy
 ```
 
-Please see the [documentation for `gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) on which options are available and how they affect the deployment.
+Please see the [documentation for `gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) on which more options are available and how they affect the deployment.
 
 Google also publishes stack and language specific tutorials for deploying to App Engine via their documentation, detailing more advanced options. See their [App Engine documentation](https://cloud.google.com/appengine/docs/) for specific articles on deploying [Ruby](https://cloud.google.com/appengine/docs/flexible/ruby/testing-and-deploying-your-app), [Node.js](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app) or [PHP](https://cloud.google.com/appengine/docs/flexible/php/testing-and-deploying-your-app) based applications (among others).

--- a/_pro/continuous-deployment/google-app-engine.md
+++ b/_pro/continuous-deployment/google-app-engine.md
@@ -1,0 +1,70 @@
+---
+title: Continuous Delivery to Google App Engine
+shortTitle: Deploying To Google App Engine
+menus:
+  pro/cd:
+    title: Google App Engine
+    weight: 5
+tags:
+  - deployment
+  - google
+  - google cloud
+  - google app engine
+  - app engine
+---
+
+* include a table of contents
+{:toc}
+
+## Deploying To Google App Engine
+
+Follow these steps to deploy your application to [Google App Engine](https://cloud.google.com/appengine/).
+
+### Authentication
+
+Deploying your application to App Engine via the `gcloud` utility only involves a couple of commands. Please follow the steps for [creating a Google Cloud service account](#authentication) and encrypting the provided credentials. Those are required to authenticate with Google Cloud during the deployment phase.
+
+### Deployment Service
+
+You will want to add a service which references the [Google Cloud deployment image]((https://hub.docker.com/r/codeship/google-cloud-deployment/), which is maintained by Codeship, in your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}). For example:
+
+```yaml
+googleclouddeployment:
+  image: codeship/google-cloud-deployment
+  encrypted_env_file: google-credentials.encrypted
+  add_docker: true
+  volumes:
+    - ./:/deploy
+```
+
+**Note** that this example adds your Google Cloud account credentials as encrypted environment variables and mounts the repository as a [volume]({{ site.baseurl }}{% link _pro/builds-and-configuration/docker-volumes.md %}) to the `/deploy` folder inside the container so that it is usable as part of the build.
+
+### Deployment Step
+
+Add the following snippet to your `codeship-steps.yml` file, referencing the service we added earlier and calling a `google-deploy.sh` script which will deploy your application to Google App Engine.
+
+```yaml
+- name: google-cloud-deployment
+  service: googleclouddeployment
+  command: google-deploy.sh
+```
+
+Following is a very basic version of an App Engine deployment script. You can customize the script to fit your specific needs, e.g. by specifying custom configuration files that will drive the deployment instead of the default `app.yml`. Save this script as `google-deploy.sh` to the root of your repository.
+
+```bash
+#!/bin/bash
+
+# Authenticate with the Google Services
+codeship_google authenticate
+
+# switch to the directory containing your app.yml (or similar) configuration file
+# note that your repository is mounted as a volume to the /deploy directory
+cd /deploy/
+
+# deploy the application
+gcloud app deploy
+```
+
+Please see the [documentation for `gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) on which options are available and how they affect the deployment.
+
+Google also publishes stack and language specific tutorials for deploying to App Engine via their documentation, detailing more advanced options. See their [App Engine documentation](https://cloud.google.com/appengine/docs/) for specific articles on deploying [Ruby](https://cloud.google.com/appengine/docs/flexible/ruby/testing-and-deploying-your-app), [Node.js](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app) or [PHP](https://cloud.google.com/appengine/docs/flexible/php/testing-and-deploying-your-app) based applications (among others).

--- a/_pro/continuous-deployment/google-cloud.md
+++ b/_pro/continuous-deployment/google-cloud.md
@@ -185,4 +185,4 @@ Google also publishes stack and language specific tutorials for deploying to App
 
 ## Container Engine And Container Registry
 
-If you are looking to use Google Container Engine and Google Container registry, we main [specific documentation]({{ site.baseurl }}{% link _pro/continuous-deployment/google-container.md %}) for using those services.
+If you are looking to use Google Container Engine and Google Container registry, we maintain [specific documentation]({{ site.baseurl }}{% link _pro/continuous-deployment/google-container.md %}) for using those services.

--- a/_pro/continuous-deployment/google-cloud.md
+++ b/_pro/continuous-deployment/google-cloud.md
@@ -157,6 +157,32 @@ As you can see, the deployment script is essentially just standard Google Cloud 
 
 You can also take a look at a [longer example we use for integration testing our container](https://github.com/codeship-library/google-cloud-deployment/blob/master/deployment/test/deploy_to_google.sh).
 
+## App Engine
+
+Deploying your application to App Engine via the `gcloud` utility only involves a couple of commands. The following steps are assuming you already [created followed the steps for authenticating](#authentication) and [added a gcloud service](#creating-your-services) to your `codeship-services.yml` file.
+
+In your repository create a script like the following to configure the individual steps required for the App Engine deployment.
+
+```bash
+#!/bin/bash
+
+# Authenticate with the Google Services
+codeship_google authenticate
+
+# switch to the directory containing your app.yml (or similar) configuration file
+# note that your repository is mounted as a volume to the /deploy directory
+cd /deploy/
+
+# deploy the application
+gcloud app deploy
+```
+
+This is the most basic version of an App Engine deployment script. You can customize the script to fit your specific needs, e.g. by specifying custom configuration files that will drive the deployment instead of the default `app.yml`.
+
+Please see the [documentation for `gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) on which options are available and how they affect the deployment.
+
+Google also publishes stack and language specific tutorials for deploying to App Engine via their documentation, detailing more advanced options. See their [App Engine documentation](https://cloud.google.com/appengine/docs/) for specific articles on deploying [Ruby](https://cloud.google.com/appengine/docs/flexible/ruby/testing-and-deploying-your-app), [Node.js](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app) or [PHP](https://cloud.google.com/appengine/docs/flexible/php/testing-and-deploying-your-app) based applications (among others).
+
 ## Container Engine And Container Registry
 
 If you are looking to use Google Container Engine and Google Container registry, we main [specific documentation]({{ site.baseurl }}{% link _pro/continuous-deployment/google-container.md %}) for using those services.

--- a/_pro/continuous-deployment/google-cloud.md
+++ b/_pro/continuous-deployment/google-cloud.md
@@ -159,29 +159,7 @@ You can also take a look at a [longer example we use for integration testing our
 
 ## App Engine
 
-Deploying your application to App Engine via the `gcloud` utility only involves a couple of commands. The following steps are assuming you already [created followed the steps for authenticating](#authentication) and [added a gcloud service](#creating-your-services) to your `codeship-services.yml` file.
-
-In your repository create a script like the following to configure the individual steps required for the App Engine deployment.
-
-```bash
-#!/bin/bash
-
-# Authenticate with the Google Services
-codeship_google authenticate
-
-# switch to the directory containing your app.yml (or similar) configuration file
-# note that your repository is mounted as a volume to the /deploy directory
-cd /deploy/
-
-# deploy the application
-gcloud app deploy
-```
-
-This is the most basic version of an App Engine deployment script. You can customize the script to fit your specific needs, e.g. by specifying custom configuration files that will drive the deployment instead of the default `app.yml`.
-
-Please see the [documentation for `gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) on which options are available and how they affect the deployment.
-
-Google also publishes stack and language specific tutorials for deploying to App Engine via their documentation, detailing more advanced options. See their [App Engine documentation](https://cloud.google.com/appengine/docs/) for specific articles on deploying [Ruby](https://cloud.google.com/appengine/docs/flexible/ruby/testing-and-deploying-your-app), [Node.js](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app) or [PHP](https://cloud.google.com/appengine/docs/flexible/php/testing-and-deploying-your-app) based applications (among others).
+Deploying your application to App Engine via the `gcloud` utility only involves a couple of commands. Head over to our [Google App Engine]({{ site.baseurl }}{% link _pro/continuous-deployment/google-app-engine.md %}) deployment articles for the details.
 
 ## Container Engine And Container Registry
 

--- a/_pro/continuous-deployment/google-container.md
+++ b/_pro/continuous-deployment/google-container.md
@@ -4,7 +4,7 @@ shortTitle: Deploying To Google Container Engine
 menus:
   pro/cd:
     title: Google Container Engine
-    weight: 5
+    weight: 6
 tags:
   - deployment
   - google
@@ -97,7 +97,7 @@ googleclouddeployment:
   encrypted_env_file: google-credentials.encrypted
   add_docker: true
   volumes:
-    - ./:/deploy  
+    - ./:/deploy
 ```
 
 **Note** that this example adds your Google Cloud account credentials as encrypted environment variables and adds the repository folder as a [volume]({{ site.baseurl }}{% link _pro/builds-and-configuration/docker-volumes.md %}) at `/deploy` so that we can use it as part of the build.


### PR DESCRIPTION
Add basic instructions on how to deploy to Google App Engine from Codeship Pro.