### PR TITLE
Update parallel coverage reporting code

### DIFF
--- a/_general/integrations/codeclimate.md
+++ b/_general/integrations/codeclimate.md
@@ -169,6 +169,7 @@ The code to use to end the parallel coverage report is:
 
 ```bash
 cc-test-reporter sum-coverage --output - --parts $PARTS coverage/codeclimate.*.json | \
+    ./cc-test-reporter upload-coverage
 ```
 
 Note that you will need to manually `$PARTS` to reflect the number of parallel threads.


### PR DESCRIPTION
The code snippet to report coverage after parallel runs to CodeClimate was missing it's second line (based on code we used to report coverage in Mothership and CodeClimate docs here: https://github.com/codeclimate/test-reporter#low-level-usage)