### PR TITLE
changed line to imply artifact.zip is not auto generated

### DIFF
--- a/_basic/continuous-integration/keep-build-artifacts.md
+++ b/_basic/continuous-integration/keep-build-artifacts.md
@@ -32,7 +32,7 @@ then add the following commands to the your setup / test steps
 
 ```shell
 pip install awscli
-aws s3 cp artifact.zip s3://mybucket/artifact.zip
+aws s3 cp your_artifact_file.zip s3://mybucket/your_artifact_file.zip
 ```
 
 For more advanced usage of the S3 CLI, please see the [S3 documentation](http://docs.aws.amazon.com/cli/latest/reference/s3/index.html) on amazon.com


### PR DESCRIPTION
https://codeship.zendesk.com/agent/tickets/14426

User expected an `artifact.zip` file to be automatically generated in the build and cited our documentation as proof.