### PR TITLE
Bring the feedback block in line with info/warnings

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -32,26 +32,25 @@ layout: default
       <div data-swiftype-name="body" data-swiftype-type="text" data-swiftype-index='true'>
         {{ content }}
       </div>
-      <div class="endcontent-block">
-        <h2>Need More Help?</h2>
-        <p>Get in touch if you need more help, or post on <a href="http://stackoverflow.com/questions/ask?tags=codeship" target="_BLANK">Stack Overflow</a> using the tag <strong>#Codeship</strong>.</p>
-          <ul>
-            <li><a href="https://helpdesk.codeship.com" target="_BLANK">Ask The Helpdesk A Question</a></li>
-            <li><a href="https://github.com/codeship-library" target="_BLANK">Code Examples And Sample Projects</a></li>
-          <ul>
 
-          <h4>Was This Article Helpful?</h4>
-            <div id="pd_rating_holder_8520732" class="polldaddy"></div>
-            <script type="text/javascript">
-            PDRTJS_settings_8520732 = {
-              "id" : "8520732",
-              "unique_id" : "8520732_{{ page.title }}",
-              "title" : "{{ page.title }}",
-              "permalink" : "{{ page.url | prepend: site.baseurl | prepend: site.url }}"
-            };
-            (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
-            </script>
+      <div class="feedback-block">
+				<h2>Need more help?</h2>
 
+				<p>Get in touch if you have any further questions. You can either post on <a href="http://stackoverflow.com/questions/ask?tags=codeship" target="_BLANK">Stack Overflow</a> using the tag <code>#codeship</code> or <a href="https://helpdesk.codeship.com">ask us a question via our Helpdesk</a>.</p>
+
+				<p>We also have a couple of <a href="https://github.com/codeship-library" target="_BLANK">code examples and sample projects</a> available, that make it easier to get started with Codeship.</p>
+
+        <h2>Was This Article Helpful?</h2>
+        <div id="pd_rating_holder_8520732" class="polldaddy"></div>
+        <script type="text/javascript">
+	        PDRTJS_settings_8520732 = {
+	          "id" : "8520732",
+	          "unique_id" : "8520732_{{ page.title }}",
+	          "title" : "{{ page.title }}",
+	          "permalink" : "{{ page.url | prepend: site.baseurl | prepend: site.url }}"
+	        };
+	        (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
+        </script>
       </div>
     </div>
   </div>

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -321,7 +321,7 @@ div#integrations {
 
   h2 {
     font: bolder 20px/1.6 "Lato", sans-serif;
-    margin: .8em 0;
+    margin: 1.2em 0 .8em 0;
     color: #fff;
   }
 
@@ -380,6 +380,7 @@ div#integrations {
 }
 
 .feedback-block {
+  padding-top: .1em;
   background-color: $_cLightgrey;
   border-color: $_cLightgrey;
 
@@ -394,6 +395,10 @@ div#integrations {
 
   code {
     background-color: $_cDarkgrey;
+  }
+
+  .rating-nero-value {
+    margin-right: 2em;
   }
 }
 

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -321,7 +321,7 @@ div#integrations {
 
   h2 {
     font: bolder 20px/1.6 "Lato", sans-serif;
-    margin: 1.2em 0 .8em 0;
+    margin: 1.2em 0 .8em;
     color: #fff;
   }
 

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -300,31 +300,34 @@ div#integrations {
 // *******************************************************
 
 .alert-block,
+.feedback-block,
 .info-block {
-  display: block;
   position: relative;
-  padding: 1rem;
+  padding: .5em;
   line-height: 1.2em;
   border: 1px solid #fff;
   border-radius: 4px;
-  padding-left: 40px;
+  padding-left: 2.4em;
   color: #fff;
-  margin: 1rem 0;
+  margin: 1.5em 0;
 
   &::before {
     font-family: 'FontAwesome';
     position: absolute;
-    top: 50%;
-    width: 40px;
-    left: 0;
-    text-align: center;
-    transform: translateY(-50%);
+    left: 1em;
+    top: .8em;
+    color: #fff;
+  }
+
+  h2 {
+    font: bolder 20px/1.6 "Lato", sans-serif;
+    margin: .8em 0;
     color: #fff;
   }
 
   p {
     font: 300 16px/1.6 "museo-sans-rounded", Arial, sans-serif;
-    margin: .2rem;
+    margin: .2em 0;
   }
 
   strong {
@@ -376,64 +379,22 @@ div#integrations {
   }
 }
 
-.endcontent-block {
-  margin: 3.5rem 0 0;
-  display: block;
-  position: relative;
-  padding: 0;
-  line-height: 1.2em;
-  border-radius: 8px;
-  padding-left: 40px;
-  background: #fff;
-  border: 3px solid $_cBlue;
-  color: #000;
-
-  p {
-    font: 300 14px/1.4 "museo-sans-rounded", Arial, sans-serif !important;
-  }
-
-  h2 {
-    margin: 2rem 0 .5rem;
-    color: #000;
-  }
+.feedback-block {
+  background-color: $_cLightgrey;
+  border-color: $_cLightgrey;
 
   &::before {
-    color: $_cBlue;
+    content: '\f059';
+    top: 1.8em;
   }
 
   a {
-    color: $_cBlue;
-    font-weight: bold;
-    border-bottom: 1px solid #fff;
+    color: $_cDarkgrey;
   }
 
-  a:hover {
-    color: $_cBlue;
-    font-weight: bold;
-    border-bottom: 1px solid $_cBlue;
+  code {
+    background-color: $_cDarkgrey;
   }
-
-  h4 {
-    color: #000;
-  }
-
-  .rating-nero-value {
-    margin: 0 3rem 0 0;
-    color: #000 !important;
-  }
-
-  strong {
-    color: #000 !important;
-  }
-
-}
-
-.polldaddy {
-  margin: 1rem 0;
-}
-
-div#rating_info_8520732 {
-  display: none !important;
 }
 
 // *******************************************************


### PR DESCRIPTION
Adapt the design of the feedback block to look similar to warnings and info blocks and re-use most of the CSS.

Staging deployment available at https://documentation.codeship.com/staging/feedback-block/pro/continuous-deployment/google-cloud/ (this article shows all 3 currently used blocks, `info`, `warning` and the always shown `feedback` block)

Screenshot from the above article
![](http://d.pr/i/6hZxlI+)