### PR TITLE
Swiftype

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,6 +32,7 @@
 
 <!-- start Swiftype -->
 <meta class="swiftype" name="url" data-type="enum" content="{{ site.url }}{{ page.url }}" />
+<meta class="swiftype" name="category" data-type="enum" content="{{ page.collection }}" />
 <meta class="swiftype" name="published_at" data-type="date" content="{{ site.time | date_to_xmlschema }}" />
 {% if page.tags %}
   {% for tag in page.tags %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -25,7 +25,7 @@ layout: default
           {% endif %}
         </div>
 
-      <h1 class="pageTitle" data-swiftype-name="title" data-swiftype-type="string"  data-swiftype-index='true'>{{ title }}</h1>
+      <h1 class="pageTitle">{{ title }}</h1>
 
       {% include read_time.html %}
 


### PR DESCRIPTION
* Add the page collection as a category meta data
* Use the contents of the `title` HTML tag for the page title (vs the currently used, shorter article title)