### PR TITLE
Fixed PR link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,4 @@ In all of the above cases, reach out to our support team at [support@codeship.co
 [gist]: https://gist.github.com/
 [fork]: http://help.github.com/fork-a-repo/
 [branch]: https://github.com/blog/1377-create-and-delete-branches
-[pr]: http://help.github.com/send-pull-requests/
+[pr]: https://help.github.com/articles/creating-a-pull-request/


### PR DESCRIPTION
GitHub's help link to the Pull Request page was outdated and I updated it with the latest link.