### PR TITLE
Upgrade Shipyard 0.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jekyll-seo-tag', '~> 2.2.3'
 gem 'jekyll-sitemap', '~> 1.1.1'
 gem 'jekyll-redirect-from', '~> 0.12.1'
 gem 'jekyll-menus', '~> 0.6.0'
-gem 'shipyard-framework', '~> 0.2.3'
+gem 'shipyard-framework', '~> 0.2.7'
 
 group :test do
   gem 'scss_lint', '~> 0.54.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     scss_lint (0.54.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
-    shipyard-framework (0.2.3)
+    shipyard-framework (0.2.7)
 
 PLATFORMS
   ruby
@@ -75,7 +75,7 @@ DEPENDENCIES
   rake (~> 12.0.0)
   sassc (~> 1.11.4)
   scss_lint (~> 0.54.0)
-  shipyard-framework (~> 0.2.3)
+  shipyard-framework (~> 0.2.7)
 
 RUBY VERSION
    ruby 2.4.1p111


### PR DESCRIPTION
This PR upgrades to `shipyard 0.2.7` now that shipyard is up and running on mothership as well.