### PR TITLE
Minor updates to the packages.sh script

### DIFF
--- a/bin/packages.sh
+++ b/bin/packages.sh
@@ -29,6 +29,7 @@ mkdir -p "${ami}"
 
 # NodeJS versions
 set +u
+# shellcheck disable=1090
 source "${HOME}/.nvm/nvm.sh"
 echo '```shell' > "${ami}/node.md"
 nvm list >> "${ami}/node.md"
@@ -58,4 +59,4 @@ echo '```' >> "${ami}/packages.md"
 tar czf "${ami}.tar.gz" "./${ami}"
 
 info "Run the following command to download the archive to your local computer"
-debug "scp -P <SSH_DEBUG_VM_PORT> rof@<SSH_DEBUG_VM_IP>:$(pwd)/${ami}.tar.gz ./"
+debug "scp -P ${CI_DEBUG_PORT} ${CI_DEBUG_USER}@${CI_DEBUG_HOST}:$(pwd)/${ami}.tar.gz ./"


### PR DESCRIPTION
* Disable the warning about a non-constant source
* Make use of the `CI_DEBUG_*` environment variables if they are set.

Those variables are not set by default, but there are ways to inject them into the debug VM during login. Get in touch if you want to know how to do this :)

(There was no new AMI, so no actual updates to the installed packages.)