### PR TITLE
Quick (and dirty) fix for some inline code blocks

### DIFF
--- a/_sass/rig/_global.scss
+++ b/_sass/rig/_global.scss
@@ -281,6 +281,7 @@ code {
   transform: translateY(-1px);
 }
 
+a > code,
 p > code,
 li > code {
   @extend .code-inline;


### PR DESCRIPTION
This fixes some inline code blocks (nested beneath anchor tags) still showing up in the old styles

![](http://d.pr/i/Xj7Vrq+)