### PR TITLE
Update builds not triggered article

### DIFF
--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -22,26 +22,28 @@ redirect_from:
 {:toc}
 
 <div class="info-block">
-If your builds are not getting triggered on Codeship, it could be that we (or a service we depend on) are experiencing a (parial) outage. In those cases, please check our [status page](http://codeshipstatus.com){:target="_blank"}. You can also follow the [@CodeshipStatus](https://twitter.com/codeship) account on Twitter.
+If your builds are not getting triggered on Codeship, it could be that we are experiencing a service interruption. Be sure to check our [status page](http://codeshipstatus.com) to monitor any potential issues. You can also follow the [@CodeshipStatus](https://twitter.com/codeship) account on Twitter.
 </div>
 
-Builds on Codeship are triggered via a webhook from your VCS. We add this hook to your repository when you configure the project on Codeship, but sometimes those settings get out of sync.
+## Webhooks
 
-That's why we show the status of the webhook configuration on the _General_ page of your project settings.
+Builds on Codeship are triggered via a webhook from your source control repository. This webhook is added to your repository when you connect the project to Codeship, but sometimes those settings get out of sync.
+
+You can find a status indicator for this webhook on the _General_ page of your project settings.
 
 ![Hook Status and Project UUID]({{ site.baseurl }}/images/faq/hook_status_and_project_uuid.png)
 
-## GitHub
+### GitHub
 
 Make sure the _Codeship_ service is added under the _Webhooks & Services_ section of your repository settings. Also check that the UUID configured for the repository matches the one shown on the _General_ page of your project settings on Codeship.
 
 ![GitHub Service Configuration]({{ site.baseurl }}/images/faq/service_github.png)
 
-## Gitlab
+### Gitlab
 
 Make sure a webhook for Codeship is added under the _Webhooks_ section in the settings of your repository. The [Gitlab documentation](https://docs.gitlab.com/ce/user/project/integrations/webhooks.html) has more information.
 
-## Bitbucket
+### Bitbucket
 
 Make sure a webhook for Codeship is added under the _Webhooks_ section in the settings of your repository. Please also check the the UUID in the hook URL matches the UUID from your project. The hook URL itself should match the following pattern.
 

--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -21,6 +21,10 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+If your builds are not getting triggered on Codeship, it could be that we (or a service we depend on) are experiencing a (parial) outage. In those cases, please check our [status page](http://codeshipstatus.com){:target="_blank"}. You can also follow the [@CodeshipStatus](https://twitter.com/codeship) account on Twitter.
+</div>
+
 Builds on Codeship are triggered via a webhook from your VCS. We add this hook to your repository when you configure the project on Codeship, but sometimes those settings get out of sync.
 
 That's why we show the status of the webhook configuration on the _General_ page of your project settings.
@@ -32,14 +36,6 @@ That's why we show the status of the webhook configuration on the _General_ page
 Make sure the _Codeship_ service is added under the _Webhooks & Services_ section of your repository settings. Also check that the UUID configured for the repository matches the one shown on the _General_ page of your project settings on Codeship.
 
 ![GitHub Service Configuration]({{ site.baseurl }}/images/faq/service_github.png)
-
--Make sure a webhook for Codeship is added under the _Webhooks_ section in the settings of your repository. Please also check the the UUID in the hook URL matches the UUID from your project. The hook URL itself should match the following pattern.
- -
- -```
- -https://lighthouse.codeship.io/bitbucket/YOUR_PROJECT_UUID
- -```
- -
- -![BitBucket Webhooks Configuration]({{ site.baseurl }}/images/general/bitbucket_webhooks.jpg)
 
 ## Gitlab
 
@@ -54,7 +50,3 @@ https://lighthouse.codeship.io/bitbucket/YOUR_PROJECT_UUID
 ```
 
 ![BitBucket Webhooks Configuration]({{ site.baseurl }}/images/general/bitbucket_webhooks.jpg)
-
-## Issues with Codeship
-
-It also might be possible that there are issues on Codeship. Please check our [Codeship Status Page](http://codeshipstatus.com){:target="_blank"} or follow us on [@Codeship](https://twitter.com/codeship) for further information.


### PR DESCRIPTION
* Fix an issue with duplicated code below the GitHub section
* Move the status page paragraph to an info block and to the top of the page.