### PR TITLE
Search breadcrumbs

### DIFF
--- a/_basic/continuous-deployment/deployment-to-aws-lambda.md
+++ b/_basic/continuous-deployment/deployment-to-aws-lambda.md
@@ -17,6 +17,14 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about deploying to AWS Lambda with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
+
+You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
+</div>
+
 ## General
 [AWS Lambda](http://aws.amazon.com/lambda/)  is a compute service that runs your code in response to events and automatically manages the compute resources for you, making it easy to build applications that respond quickly to new information.
 

--- a/_basic/continuous-deployment/deployment-to-digitalocean.md
+++ b/_basic/continuous-deployment/deployment-to-digitalocean.md
@@ -16,7 +16,16 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about deploying to DigitalOcean with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
+
+You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
+</div>
+
 ## Getting Started with DigitalOcean
+
 DigitalOcean offers virtual servers (called Droplets). If you have not yet set up a Droplet, check out [DigitalOcean's tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet-virtual-server).
 
 While not necessary, selecting the Ubuntu 14.04 image for your Droplet will provide even greater parity between your production and [CI/CD environment]({{ site.baseurl }}{% link _general/about/vm-and-infrastructure.md %}).

--- a/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
+++ b/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
@@ -21,9 +21,11 @@ redirect_from:
 {:toc}
 
 <div class="info-block">
-  You might also want to check out these related articles:
-  * [Codeship public SSH key]({{ site.baseurl }}{% link _general/projects/project-ssh-key.md %})
-  * [Deployment via Custom Script]({{ site.baseurl }}{% link _basic/continuous-deployment/deployment-with-custom-scripts.md %})
+This article is about deploying via SFTP with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic).
+
+You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
 </div>
 
 After your code passed through the pipeline successfully, the last step in your CI chain is deploying your code. You're either using one of our many integrations or deploying with your own script. If you're using your own means of deployment, we recommend tools like rsync, [Capistrano (Ruby)](http://capistranorb.com/), [Rocketeer (PHP)](http://rocketeer.autopergamene.eu/), [Deployer (PHP)](https://deployer.org/), or [Fabric (Python)](http://www.fabfile.org/).

--- a/_basic/continuous-integration/browser-testing.md
+++ b/_basic/continuous-integration/browser-testing.md
@@ -27,7 +27,15 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about running browser testing in your CI/CD pipeline with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
+</div>
+
+
 ## Chrome
+
 Current versions of Google Chrome and Chromium are installed by default.
 
 Google Chrome is at version 60 and is located at `/usr/bin/google-chrome`.
@@ -42,9 +50,11 @@ ln -sf /usr/bin/chromium-browser /home/rof/bin/Chrome
 ```
 
 ### Headless Chrome
+
 Beginning in Google Chrome 59, you can run Chrome in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome). To take advantage of this be sure your build is targeting Google Chrome and using ChromeDriver 2.30 or greater.  Your application will also need to pass the `headless` and `disable-gpu` flags to Chrome.
 
 ## ChromeDriver
+
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver) 2.31 is installed by default and available in the PATH.
 
 To install a [custom ChromeDriver version](https://github.com/codeship/scripts/blob/master/packages/chromedriver.sh) add the following commands to your build steps:
@@ -56,6 +66,7 @@ export CHROMEDRIVER_VERSION=YOUR_DESIRED_VERSION
 ```
 
 ## Firefox
+
 Firefox 35.0.1 is installed by default and available in the PATH.
 
 To install a [custom Firefox version](https://github.com/codeship/scripts/blob/master/packages/firefox.sh) add the following commands to your build steps:
@@ -67,6 +78,7 @@ export FIREFOX_VERSION=YOUR_DESIRED_VERSION
 ```
 
 ## geckodriver
+
 geckodriver 0.11.1 is installed by default and available in the PATH.
 
 To install a [custom geckodriver version](https://github.com/codeship/scripts/blob/master/packages/geckodriver.sh) add the following commands to your build steps:
@@ -80,17 +92,21 @@ source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/sc
 ```
 
 ## Selenium
+
 Chrome and Firefox both work with Selenium. To support Selenium with Chrome be sure to update ChromeDriver to the desired version for your application. Please provide your own Selenium driver in your application and keep it current.
 
 ### Selenium Standalone Server
+
 If there are no packages available for your framework or you want to use the standalone version there is a [script](https://github.com/codeship/scripts/blob/master/packages/selenium_server.sh) available for installing a custom version.
 
 ## Sauce Labs
+
 You can use [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy) to connect the Sauce Labs browser testing service with the application running in your Codeship build.
 
 There is a [script](https://github.com/codeship/scripts/blob/master/packages/sauce_connect.sh) available for installing Sauce Connect in the build environment. Make sure you set the username and API key or other necessary variables in the [environment configuration]({{ site.baseurl }}{% link _basic/builds-and-configuration/set-environment-variables.md %}). You can run your tests exactly the same way as you would run them on your own development machine through Sauce Connect.
 
 ## PhantomJS
+
 [PhantomJS](http://phantomjs.org) 1.9.7 is installed by default and available in the PATH.
 
 To install a [custom PhantomJS version](https://github.com/codeship/scripts/blob/master/packages/phantomjs.sh) add the following commands to your build steps:
@@ -102,7 +118,9 @@ export PHANTOMJS_VERSION=YOUR_DESIRED_VERSION
 ```
 
 ## SlimerJS
+
 [SlimerJS](https://slimerjs.org) 0.9.5 is installed by default and available in the PATH.
 
 ## CasperJS
+
 [CasperJS](http://casperjs.org) 1.1.0-beta3 is installed by default and available in the PATH.

--- a/_basic/continuous-integration/run-a-command-in-the-background.md
+++ b/_basic/continuous-integration/run-a-command-in-the-background.md
@@ -14,8 +14,16 @@ redirect_from:
   - /continuous-integration/run-a-command-in-the-background/
 ---
 
+<div class="info-block">
+This article is about running a service or a command in the background of your CI/CD pipeline with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
+</div>
+
 * include a table of contents
 {:toc}
+
+## Running A Command In The Background
 
 If you need to run a process in the background during your builds (e.g. to run a service not available by default, or to run a development server provided by your application framework) you can use the following templates to do so.
 

--- a/_basic/languages-frameworks/nodejs.md
+++ b/_basic/languages-frameworks/nodejs.md
@@ -21,6 +21,12 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about using Node.js with Codeship Basic.
+
+If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
+</div>
+
 ## Versions And Setup
 
 We use **nvm** to manage different node versions. We read the node version you set in your **package.json** and install the appropriate one. You can use **nvm** in your [setup commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}), such as:

--- a/_pro/builds-and-configuration/build-arguments.md
+++ b/_pro/builds-and-configuration/build-arguments.md
@@ -30,7 +30,7 @@ This article is about using Docker build arguments with Codeship Pro.
 
  If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
- Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _ro/builds-and-configuration/cli.md %}) to encrypt your build arguments.
+ Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/builds-and-configuration/cli.md %}) to encrypt your build arguments.
 </div>
 
 ## Overview: Build Arguments

--- a/_pro/builds-and-configuration/build-arguments.md
+++ b/_pro/builds-and-configuration/build-arguments.md
@@ -24,7 +24,13 @@ redirect_from:
 {:toc}
 
 <div class="info-block">
-This article covers using Docker build arguments with Codeship Pro. If you are unfamiliar with either, we recommend [Docker's build arguments documentation](https://docs.docker.com/engine/reference/builder/#arg) as well as the [Codeship Pro Getting Started Guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}).
+This article is about using Docker build arguments with Codeship Pro.
+
+ If you are unfamiliar with build arguments, we recommend reading [Docker's build arguments documentation](https://docs.docker.com/engine/reference/builder/#arg).
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+ Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _ro/builds-and-configuration/cli.md %}) to encrypt your build arguments.
 </div>
 
 ## Overview: Build Arguments

--- a/_pro/builds-and-configuration/cli.md
+++ b/_pro/builds-and-configuration/cli.md
@@ -28,7 +28,7 @@ redirect_from:
 ---
 
 <div class="info-block">
-This article is about the local CLI tool that you can use to test and debug your Codeship Pro builds and configuration files as well as to encrypt your [environment variables]({{ site.baseurl }}{% link _ro/builds-and-configuration/environment-variables.md %}) and [build arguments]({{ site.baseurl }}{% link _ro/builds-and-configuration/build-arguments.md %}).
+This article is about the local CLI tool that you can use to test and debug your Codeship Pro builds and configuration files as well as to encrypt your [environment variables]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}) and [build arguments]({{ site.baseurl }}{% link _pro/builds-and-configuration/build-arguments.md %}).
 
  If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 

--- a/_pro/builds-and-configuration/cli.md
+++ b/_pro/builds-and-configuration/cli.md
@@ -28,6 +28,15 @@ redirect_from:
 ---
 
 <div class="info-block">
+This article is about the local CLI tool that you can use to test and debug your Codeship Pro builds and configuration files as well as to encrypt your [environment variables]({{ site.baseurl }}{% link _ro/builds-and-configuration/environment-variables.md %}) and [build arguments]({{ site.baseurl }}{% link _ro/builds-and-configuration/build-arguments.md %}).
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+ Note that if you are using Codeship Basic, you will not be able to use the local CLI.
+</div>
+
+
+<div class="info-block">
 Jet is used to locally debug and test builds for Codeship Pro, as well as to assist with several important tasks like encrypting secure credentials. If you are using Codeship Basic, you will not need to use Jet.
 </div>
 

--- a/_pro/builds-and-configuration/environment-variables.md
+++ b/_pro/builds-and-configuration/environment-variables.md
@@ -24,7 +24,7 @@ This article is about using environment variables with Codeship Pro.
 
  If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
- Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _ro/builds-and-configuration/cli.md %}) to encrypt your environment variables.
+ Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/builds-and-configuration/cli.md %}) to encrypt your environment variables.
 </div>
 
 

--- a/_pro/builds-and-configuration/environment-variables.md
+++ b/_pro/builds-and-configuration/environment-variables.md
@@ -20,8 +20,13 @@ redirect_from:
 ---
 
 <div class="info-block">
-To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% link _pro/builds-and-configuration/cli.md %}).
+This article is about using environment variables with Codeship Pro.
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+ Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _ro/builds-and-configuration/cli.md %}) to encrypt your environment variables.
 </div>
+
 
 * include a table of contents
 {:toc}

--- a/_pro/builds-and-configuration/services.md
+++ b/_pro/builds-and-configuration/services.md
@@ -21,6 +21,14 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about the `codeship-services.yml` file that powers Codeship Pro.
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+ Also note that the `codeship-services.yml` file depends on the `codeship-steps.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}).
+</div>
+
 ## What Is Your Codeship Services File?
 Your services file - `codeship-services.yml` - is where you configure each service you need to run your CI/CD builds with Codeship. During the build, these services will be used to run the testing steps you've defined in your `codeship-steps.yml` [file]({% link _pro/builds-and-configuration/steps.md %}). You can have as many services as you'd like, and customize each of them. Each of these services will be run inside a Docker container.
 

--- a/_pro/builds-and-configuration/steps.md
+++ b/_pro/builds-and-configuration/steps.md
@@ -25,6 +25,14 @@ redirect_from:
 * include a table of contents
 {:toc}
 
+<div class="info-block">
+This article is about the `codeship-steps.yml` file that powers Codeship Pro.
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+ Also note that the `codeship-steps.yml` file depends on the `codeship-services.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}).
+</div>
+
 ## What Is codeship-steps.yml?
 
 `codeship-steps.yml` contains all the Steps for your CI/CD process. Steps are used for the `jet steps` command, which defines your continuous integration and delivery steps. By default, steps are expected to be in one of these 2 files:

--- a/_pro/continuous-deployment/aws.md
+++ b/_pro/continuous-deployment/aws.md
@@ -18,7 +18,11 @@ redirect_from:
 ---
 
 <div class="info-block">
-You can find a sample repo for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
+This article is about deploying to Heroku using Codeship Pro.
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
+You can find a sample repository for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
 </div>
 
 * include a table of contents

--- a/_pro/continuous-deployment/heroku.md
+++ b/_pro/continuous-deployment/heroku.md
@@ -15,6 +15,10 @@ redirect_from:
 ---
 
 <div class="info-block">
+This article is about deploying to Heroku using Codeship Pro.
+
+ If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+
 You can find a sample repository for deploying to Heroku with Codeship Pro on Github [here](https://github.com/codeship-library/heroku-deployment).
 </div>
 


### PR DESCRIPTION
@mlocher The idea here would be to note when we ship this and then measure 30/60/90 days, in GA, organic search traffic to these pages to see if pages per session and bounce rate changes, as well as look as next page path to see if these links are being used.

This will help us figure out if this is an effective way to assist search traffic and therefore we should roll it out across all articles or if we should revisit how this is being done.

Edit: To clarify, these articles were picked because they're our most popular organic search articles and so make the best test.