### PR TITLE
Update published Docker version to 17.10

### DIFF
--- a/_data/docker.yml
+++ b/_data/docker.yml
@@ -1,1 +1,1 @@
-version: "17.07"
+version: "17.10"


### PR DESCRIPTION
[DO NOT MERGE]

https://github.com/codeship/jet-base-ami/pull/105


I couldn't find any other references to the Docker version, so please let me know if I missed something.