### PR TITLE
updating API link to point to v2 instead of v1

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -16,7 +16,7 @@ main:
     url: /more-resources
   - title: API
     identifier: api
-    url: https://codeship-api.api-docs.io/v1/introduction/auth
+    url: https://apidocs.codeship.com/v2
 
 general:
   - &GENERAL_ABOUT


### PR DESCRIPTION
v2 is getting ready to go out of Beta, so we shouldn't be pointing to v1 anymore