### PR TITLE
Fix redirects

### DIFF
--- a/_general/integrations/api.md
+++ b/_general/integrations/api.md
@@ -11,9 +11,9 @@ tags:
 categories:
   - Builds and Configuration  
 redirect_from:
-  - /integration/api
+  - /integration/api/
   - /basic/getting-started/api/
-  - /basic/builds-and-configuration/api
+  - /basic/builds-and-configuration/api/
 ---
 
 * include a table of contents


### PR DESCRIPTION
Redirects should always end with a slash otherwise Jekyll will create e.g. an `api.html` which correctly redirects, but is never linked to.