### PR TITLE
Update Jet docs to point to our custom cask

### DIFF
--- a/_pro/builds-and-configuration/cli.md
+++ b/_pro/builds-and-configuration/cli.md
@@ -66,13 +66,11 @@ shasum -c -a 256 sha256sums
 
 ### Installing Jet On Mac OS X
 
-The `jet` CLI is now included in [Homebrew Cask](https://caskroom.github.io/). If you already have [Homebrew installed](http://brew.sh/) and the [Caskroom tapped](https://caskroom.github.io/)[^1] you can install `jet` by running the following command
+The `jet` CLI is now included in our custom [Homebrew Cask](https://github.com/codeship/homebrew-taps/tree/master/Casks). If you already have [Homebrew installed](http://brew.sh/) you can install `jet` by running the following command
 
 ```shell
-brew cask install jet
+brew cask install codeship/taps/jet
 ```
-
-The formula will install Docker as well. If you already have Docker installed, but didn't use Homebrew to install it, you will be asked by Homebrew if you want to overwrite the Docker binary. If you don't want to manage Docker via Homebrew, please use the alternative installation method below.
 
 If you don't have Homebrew installed or don't use Homebrew Cask you can install `jet` via the following commands.
 
@@ -81,8 +79,6 @@ curl -SLO "{{ site.data.jet.base_url }}/{{ site.data.jet.version }}/jet-darwin_a
 tar -xC /usr/local/bin/ -f jet-darwin_amd64_{{ site.data.jet.version }}.tar.gz
 chmod u+x /usr/local/bin/jet
 ```
-
-[^1]: Instructions for tapping the _Caskroom_ are at the very bottom of the page.
 
 ### Installing Jet On Linux
 


### PR DESCRIPTION
As of now we're going to move to use our own Homebrew Cask as it gives us more control over when we release jet (we don't have to wait for the homebrew-cask people to merge our PRs).

Im updating the docs to reflect this.

I'm going to work with the homebrew-cask team to deprecate or remove or existing cask there.

We are also changing the way our Changelog is managed. It will not be managed manually and stored as CHANGELOG.md in the releases directory on s3, so we should probably talk about how we keep the Release Notes page up to date with this in the future.