### PR TITLE
Updating jet docs script to use local /site directory and not root /site

### DIFF
--- a/bin/jet.sh
+++ b/bin/jet.sh
@@ -4,14 +4,14 @@ log() { echo -e "\033[36m$@\033[39m"; }
 
 # configuration
 unset $latest_version
-target="/site/.jet"
+target="./site/.jet"
 
 log "Preparing Jet release notes and current version"
 rm -rf "${target}" && mkdir -p "${target}/sync"
 aws s3 sync "s3://${JET_RELEASE_BUCKET}/" "${target}/sync" --exclude "*" --include "*.changelog" --quiet
 
 # write the release notes
-find "${target}/sync/" -name "*.changelog" -type f -not -size 0 | natsort -r | \
+find "${target}/sync/" -name "*.changelog" -type f -not -size 0 | sort -r -V | \
 while read line; do
 	version=$(basename ${line} | sed -e 's/\.changelog//')
 	if [ -z "${latest_version}" ]; then


### PR DESCRIPTION
Ran into some issues when trying to run locally, also don't have `natsort` and couldnt figure out how to install it on macOS. 

GNU sort supports the `-V` flag which can be used to do what we need:

```
-V, --version-sort
             Sort version numbers.
```