### PR TITLE
Jet v2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :serve do
 	sh "docker run -it --rm -p 4000:4000 -v $(pwd):/docs #{IMAGE_NAME}"
 end
 namespace :serve do
-	desc "Serve a locally available site (from the ./tmp/site/ directory) via nginx"
+	desc "Serve a local site (from the ./tmp/site/ directory, which is populated by `jet steps`) via nginx"
 	task :local do
 		sh "docker run -it --rm -p 4000:80 -v $(pwd)/tmp/site:/usr/share/nginx/html:ro nginx:alpine"
 	end

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,12 @@ desc 'Run the development server'
 task :serve do
 	sh "docker run -it --rm -p 4000:4000 -v $(pwd):/docs #{IMAGE_NAME}"
 end
+namespace :serve do
+	desc "Serve a locally available site (from the ./tmp/site/ directory) via nginx"
+	task :local do
+		sh "docker run -it --rm -p 4000:80 -v $(pwd)/tmp/site:/usr/share/nginx/html:ro nginx:alpine"
+	end
+end
 
 desc 'Run tests'
 task :test do

--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,9 @@ exclude:
   - codeship-steps.yml
   - codeship.aes
   - CONTRIBUTING.md
+  - deployment.env*
+  - dockercfg*
+  - Dockerfile*
   - external
   - Gemfile*
   - Guardfile
@@ -72,9 +75,12 @@ exclude:
   - node_modules
   - npm-shrinkwrap.json
   - package.json
+  - Rakefile
   - README.md
   - SUPPORT.md
   - templates
+  - tmp
+  - yarn.lock
 encoding: utf-8
 plugins:
   - jekyll-coffeescript

--- a/_pro/builds-and-configuration/cli.md
+++ b/_pro/builds-and-configuration/cli.md
@@ -26,7 +26,7 @@ redirect_from:
   - /pro/getting-started/installation/
   - /docker/cli/
   - /pro/cli/
-  - /jet/  
+  - /jet/
   - /docker/getting-started/installation/
 ---
 
@@ -70,6 +70,9 @@ The `jet` CLI is now included in our custom [Homebrew Cask](https://github.com/c
 
 ```shell
 brew cask install codeship/taps/jet
+
+# If you already have the CLI installed and want to update to the latest version
+brew case reinstall codeship/taps/jet
 ```
 
 If you don't have Homebrew installed or don't use Homebrew Cask you can install `jet` via the following commands.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -27,9 +27,7 @@ if [ -f "_data/jet.yml" ]; then
 fi
 
 if [ -f "_pro/builds-and-configuration/release-notes.md" ]; then
-	log "Copying changelog to destination"
 	cat "${jet_source}/CHANGELOG.md" >> "_pro/builds-and-configuration/release-notes.md"
-	cat "_pro/builds-and-configuration/release-notes.md"
 fi
 
 rm -rf "${jet_source}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-log() { echo -e "\033[36m$@\033[39m"; }
+log() { echo -e "\033[36m$*\033[39m"; }
 
 # Special settings for the "master" branch, compile the site to the "master"
 # subdirectory, but use an empty baseurl, so we can deploy to the bucket root
@@ -27,7 +27,9 @@ if [ -f "_data/jet.yml" ]; then
 fi
 
 if [ -f "_pro/builds-and-configuration/release-notes.md" ]; then
-	cat "${jet_source}/release-notes" >> "_pro/builds-and-configuration/release-notes.md"
+	log "Copying changelog to destination"
+	cat "${jet_source}/CHANGELOG.md" >> "_pro/builds-and-configuration/release-notes.md"
+	cat "_pro/builds-and-configuration/release-notes.md"
 fi
 
 rm -rf "${jet_source}"

--- a/bin/jet.sh
+++ b/bin/jet.sh
@@ -1,38 +1,13 @@
 #!/bin/sh
 set -e
-log() { echo -e "\033[36m$@\033[39m"; }
+log() { echo -e "\033[36m$*\033[39m"; }
 
 # configuration
-unset $latest_version
 target="/site/.jet"
 
 log "Preparing Jet release notes and current version"
 rm -rf "${target}" && mkdir -p "${target}/sync"
-aws s3 sync "s3://${JET_RELEASE_BUCKET}/" "${target}/sync" --exclude "*" --include "*.changelog" --quiet
-
-# write the release notes
-find "${target}/sync/" -name "*.changelog" -type f -not -size 0 | natsort -r | \
-while read line; do
-	version=$(basename ${line} | sed -e 's/\.changelog//')
-	if [ -z "${latest_version}" ]; then
-		# set the latest version on the first iteration of the while loop
-		latest_version=${version}
-		echo "${latest_version}" > "${target}/version"
-	fi
-	cat >> "${target}/release-notes" <<-EOF
-
-		## ${version}
-
-		$(cat ${line})
-	EOF
-done
-
-# TODO
-# surround "{{...}}" tags with {% raw %}...{% endrawr %} as those are used for
-# both go templates as well as the Jekyll templating system
-
-# cleanup
-rm -rf "${target}/sync"
+aws s3 sync "s3://${JET_RELEASE_BUCKET}/latest/" "${target}/"
 
 # print the latest version
 log "Latest version is $(cat "${target}/version")"


### PR DESCRIPTION
adapt to the new Jet v2 build process and the updated Changelog and version locations.

Staging build running at https://app.codeship.com/projects/102044/builds/f2a4acf7-4bf2-43f5-b4f9-55e05eb34b7b.

The ChangeLog from the staging build is available at https://documentation.codeship.com/staging/jet-v2/pro/builds-and-configuration/release-notes/, the install instructions are at https://documentation.codeship.com/staging/jet-v2/pro/builds-and-configuration/cli/