### PR TITLE
Adding deployments to robots allow

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,4 +10,9 @@ User-agent: *
 Disallow: /staging/
 Disallow: /private/
 Disallow: /tags/
+Allow: /tags/aws
+Allow: /tags/azure
+Allow: /tags/google
+Allow: /tags/heroku
+Allow: /tags/ibm
 Sitemap: https://documentation.codeship.com/sitemap.xml


### PR DESCRIPTION
Not sure if Swifttype will recognize `allow`, Google does but some others don't.

Will try this out, reindex and see if it works.