### PR TITLE
PostgreSQL 10.2 moves to 10.3

### DIFF
--- a/_basic/databases/postgresql.md
+++ b/_basic/databases/postgresql.md
@@ -35,7 +35,7 @@ You need to activate them with `CREATE EXTENSION` as explained in the [Extension
 
 PostgreSQL 9.2 officially reached it's End-of-Life (EOL) (see [the PostgreSQL site for details](https://www.postgresql.org/support/versioning/)) which means that we will remove it from the Codeship Basic build image on **March 29, 2018**.
 
-Since PostgreSQL 9.2 is currently running on port 5432, we will move PostgreSQL 10.2 from 5437 to 5432 to make 10.2 the new default. This should have minimal impact on users as PostgreSQL are generally very well backwards compatible, but we encourage you to try out 10.2 before March 29, 2018 to avoid any unexpected surprises.
+Since PostgreSQL 9.2 is currently running on port 5432, we will move PostgreSQL 10.3 from 5437 to 5432 to make 10.3 the new default. This should have minimal impact on users as PostgreSQL are generally very well backwards compatible, but we encourage you to try out 10.3 before March 29, 2018 to avoid any unexpected surprises.
 
 ### Python & earlier psycopg2 versions
 
@@ -95,9 +95,9 @@ Similar to the other versions, you need to work around our auto-configuration fo
 sed -i "s|5432|5436|" "config/database.yml"
 ```
 
-### 10.2
+### 10.3
 
-PostgreSQL version **10.2** is running on port `5437` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
+PostgreSQL version **10.3** is running on port `5437` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
 
 Similar to the other versions, you need to work around our auto-configuration for Rails based projects by adding the following command to your _Setup Commands_.
 
@@ -105,7 +105,7 @@ Similar to the other versions, you need to work around our auto-configuration fo
 sed -i "s|5432|5437|" "config/database.yml"
 ```
 
-**Note**: the port `5437` is only temporary. Once we've fully deprecated PostgreSQL 9.2 on March 31st, 10.2 will be moved to the default port `5432`.
+**Note**: Port `5437` is temporary. Once PostgreSQL 9.2 is deprecated on March 29, 10.3 will be moved to the default port `5432`.
 
 ### pg_dump
 You may experience a `pg_dump` version mismatch with the PostgreSQL version you have configured.


### PR DESCRIPTION
```
$ psql -p 5437
psql (10.3 (Ubuntu 10.3-1.pgdg14.04+1))
```