### PR TITLE
Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "2.5.0"
 
 gem 'rake', '~>12.3.0'
-gem 'jekyll', '~> 3.7.0'
+gem 'jekyll', '~> 3.8.0'
 gem 'sassc', '~> 1.11.4'
 gem 'shipyard-framework', '~> 0.8.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.3)
+    jekyll (3.8.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -107,7 +107,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    shipyard-framework (0.8.0)
+    shipyard-framework (0.8.1)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
     sprockets (3.7.1)
@@ -125,7 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.7.0)
+  jekyll (~> 3.8.0)
   jekyll-coffeescript (~> 1.1.0)
   jekyll-menus (~> 0.6.0)
   jekyll-redirect-from (~> 0.13.0)

--- a/Rakefile
+++ b/Rakefile
@@ -39,12 +39,12 @@ namespace :update do
 	end
 
 	desc 'Update Ruby based dependencies'
-	task rubygems: %w[update:image build] do
+	task :rubygems do
 		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} bundle lock --update"
 	end
 
 	desc 'Update NodeJS based dependencies'
-	task yarn: %w[update:image build] do
+	task :yarn do
 		sh "docker run -it --rm -v $(pwd):/docs #{IMAGE_NAME} yarn upgrade"
 	end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,8 +370,8 @@ chalk@^1.0.0:
     supports-color "^2.0.0"
 
 chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -3258,8 +3258,8 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
Update to Jekyll 3.8, https://jekyllrb.com/news/2018/04/19/jekyll-3-8-0-released/