### PR TITLE
Switch to the Shipyard Note component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby "2.5.0"
 gem 'rake', '~>12.3.0'
 gem 'jekyll', '~> 3.8.0'
 gem 'sassc', '~> 1.11.4'
-gem 'shipyard-framework', '~> 0.8.0'
+gem 'shipyard-framework', '~> 0.9.0'
 
 # Jekyll Plugins
 gem 'jekyll-coffeescript', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -107,7 +107,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    shipyard-framework (0.8.1)
+    shipyard-framework (0.9.0)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
     sprockets (3.7.1)
@@ -134,7 +134,7 @@ DEPENDENCIES
   rake (~> 12.3.0)
   sassc (~> 1.11.4)
   scss_lint (~> 0.56.0)
-  shipyard-framework (~> 0.8.0)
+  shipyard-framework (~> 0.9.0)
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/README.md
+++ b/README.md
@@ -141,3 +141,15 @@ generates the following output:
 ```
 http://manpages.ubuntu.com/manpages/trusty/en/man1/formatdb.1.html
 ```
+
+#### Notes
+
+You can include `note` sections on the pages via the `csnote` helper. Those blocks are powered by the [Shipyard Notes component](https://codeship.github.io/shipyard/components/notes)
+
+```
+{% csnote info %}
+Some informational text.
+{% endcsnote %}
+```
+
+As an optional argument you can specify either `info`, `success` or `warning`. If you don't specify the argument a default (grey) note will be used.

--- a/_basic/builds-and-configuration/dependency-cache.md
+++ b/_basic/builds-and-configuration/dependency-cache.md
@@ -11,7 +11,7 @@ tags:
   - speed
   - caching
 categories:
-  - Builds and Configuration  
+  - Builds and Configuration
 redirect_from:
   - /basic/getting-started/dependency-cache/
 ---
@@ -19,9 +19,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 Note that this article addresses caching on **Codeship Basic**. If you are looking for information on caching with **Codeship Pro**, [click here]({{ site.baseurl }}{% link _pro/builds-and-configuration/caching.md %})
-</div>
+{% endcsnote %}
 
 ## What Is The Dependency Cache?
 

--- a/_basic/builds-and-configuration/packages.md
+++ b/_basic/builds-and-configuration/packages.md
@@ -15,9 +15,9 @@ redirect_from:
   - /basic/getting-started/packages/
 ---
 
-<div class="info-block">
+{% csnote info %}
 This page was last updated on {{ site.data.basic.latest_update }}.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_basic/builds-and-configuration/parallel-tests.md
+++ b/_basic/builds-and-configuration/parallel-tests.md
@@ -14,7 +14,7 @@ tags:
   - parallel
   - concurrency
 categories:
-  - Builds and Configuration  
+  - Builds and Configuration
   - Continuous Integration
 redirect_from:
   - /continuous-integration/parallelci/
@@ -23,9 +23,9 @@ redirect_from:
   - /basic/builds-and-configuration/parallelci/
 ---
 
-<div class="info-block">
+{% csnote info %}
 Parallel test pipelines are an account upgrade. You can try [a free trial](https://codeship.com/projects#start-trial) to test using up to 20 parallel test pipelines for two weeks on all your projects.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_basic/continuous-deployment/deployment-to-aws-lambda.md
+++ b/_basic/continuous-deployment/deployment-to-aws-lambda.md
@@ -10,7 +10,7 @@ tags:
   - lambda
   - aws
 categories:
-  - Continuous Deployment  
+  - Continuous Deployment
 redirect_from:
   - /continuous-deployment/deployment-to-aws-lambda/
 ---
@@ -18,13 +18,13 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about deploying to AWS Lambda with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
 
 You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
-</div>
+{% endcsnote %}
 
 ## General
 [AWS Lambda](http://aws.amazon.com/lambda/)  is a compute service that runs your code in response to events and automatically manages the compute resources for you, making it easy to build applications that respond quickly to new information.

--- a/_basic/continuous-deployment/deployment-to-digitalocean.md
+++ b/_basic/continuous-deployment/deployment-to-digitalocean.md
@@ -9,7 +9,7 @@ tags:
   - digital ocean
   - digitalocean
 categories:
-  - Continuous Deployment   
+  - Continuous Deployment
 redirect_from:
   - /continuous-deployment/deployment-to-digitalocean/
 ---
@@ -17,13 +17,13 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about deploying to DigitalOcean with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
 
 You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
-</div>
+{% endcsnote %}
 
 ## Getting Started with DigitalOcean
 

--- a/_basic/continuous-deployment/deployment-to-google-app-engine.md
+++ b/_basic/continuous-deployment/deployment-to-google-app-engine.md
@@ -10,7 +10,7 @@ tags:
   - gae
   - google
 categories:
-  - Continuous Deployment   
+  - Continuous Deployment
 redirect_from:
   - /continuous-deployment/deployment-to-google-app-engine/
   - /tutorials/continuous-deployment-google-app-engine-github-django-python/
@@ -43,9 +43,9 @@ The last thing needed is to specify the permissions needed for the service accou
 
 That's it. Once you save the new service account a key file will be generated and automatically downloaded to your computer.
 
-<div class="info-block">
+{% csnote info %}
 The key file is very important to keep safe as it provides the keys to pushing deployments to your project. Treat it like any other password, and keep it in a safe place.
-</div>
+{% endcsnote %}
 
 ### Step 2 - Navigate to Deployment Configuration
 

--- a/_basic/continuous-deployment/deployment-to-heroku.md
+++ b/_basic/continuous-deployment/deployment-to-heroku.md
@@ -8,7 +8,7 @@ tags:
   - deployment
   - heroku
 categories:
-  - Continuous Deployment  
+  - Continuous Deployment
 redirect_from:
   - /continuous-deployment/deployment-to-heroku/
   - /faq/push-to-heroku-rejected/
@@ -21,10 +21,11 @@ redirect_from:
 
 Codeship makes it easy to deploy your application to Heroku using Codeship's integrated [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}).
 
-<div class="info-block">
+{% csnote info %}
 Note that this documentation refers to the new Heroku Deployment template, which uses the Heroku API instead of the older `git push` method. The main difference between the two methods is that the new method copies files from the build environment directly to Heroku, as opposed to the old method that pushed the final files to a git repo, which Heroku then deployed from.
+
 For more details on how the Heroku Platform API works, see the [Heroku Dev Center](https://devcenter.heroku.com/articles/platform-api-quickstart)
-</div>
+{% endcsnote %}
 
 ## Setup Heroku Deployment
 

--- a/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
+++ b/_basic/continuous-deployment/deployment-with-ftp-sftp-scp.md
@@ -22,13 +22,13 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about deploying via SFTP with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic).
 
 You should also be aware of how [deployment pipelines]({{ site.baseurl }}{% link _basic/builds-and-configuration/deployment-pipelines.md %}) work on Codeship Basic.
-</div>
+{% endcsnote %}
 
 After your code passed through the pipeline successfully, the last step in your CI chain is deploying your code. You're either using one of our many integrations or deploying with your own script. If you're using your own means of deployment, we recommend tools like rsync, [Capistrano (Ruby)](http://capistranorb.com/), [Rocketeer (PHP)](http://rocketeer.autopergamene.eu/), [Deployer (PHP)](https://deployer.org/), or [Fabric (Python)](http://www.fabfile.org/).
 
@@ -39,9 +39,9 @@ Our recommendation if you do not want to use a deployment tool or one of our int
 1. Add the Codeship public key to your `~/.ssh/authorized_keys` file, see [Authenticating via SSH Public Keys](#authenticating-via-ssh-public-keys).
 2. Create a deployment script, see [Run commands on a remote server via SSH](#run-commands-on-a-remote-server-via-ssh). At the very least, you will have to copy all files needed by your application to the server and start the services needed by your application.
 
-<div class="info-block">
+{% csnote info %}
 When Codeship checks out your repository, we clone it to a folder called `clone` directly beneath the home directory. So when you see references to `~/clone/` folder, we talk about our local copy of your repository.
-</div>
+{% endcsnote %}
 
 **Table of Contents**
 * include a table of contents

--- a/_basic/continuous-integration/browser-testing.md
+++ b/_basic/continuous-integration/browser-testing.md
@@ -32,12 +32,11 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about running browser testing in your CI/CD pipeline with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic).
-</div>
-
+{% endcsnote %}
 
 ## Chrome
 

--- a/_basic/continuous-integration/git-submodules.md
+++ b/_basic/continuous-integration/git-submodules.md
@@ -24,9 +24,9 @@ If your repository includes a `.gitmodules` file, Codeship will automatically in
 git submodule update --recursive --init
 ```
 
-<div class="info-block">
-  Right now there is not a way to skip this command, but let us know if that creates a problem for your build.
-</div>
+{% csnote info %}
+Right now there is not a way to skip this command, but let us know if that creates a problem for your build.
+{% endcsnote %}
 
 ## Submodule Permissions
 

--- a/_basic/continuous-integration/keep-build-artifacts.md
+++ b/_basic/continuous-integration/keep-build-artifacts.md
@@ -37,9 +37,9 @@ pip install awscli
 aws s3 cp your_artifact_file.zip s3://mybucket/your_artifact_file.zip
 ```
 
-<div class="info-block">
+{% csnote info %}
 For Codeship Pro, our [_Codeship AWS container_]({{ site.baseurl }}{% link _pro/continuous-deployment/aws.md %}) can be implemented to transfer artifacts to S3 storage.
-</div>
+{% endcsnote %}
 
 For more advanced usage of the S3 CLI, please see the [S3 documentation](http://docs.aws.amazon.com/cli/latest/reference/s3/index.html) on amazon.com
 

--- a/_basic/continuous-integration/run-a-command-in-the-background.md
+++ b/_basic/continuous-integration/run-a-command-in-the-background.md
@@ -15,14 +15,11 @@ redirect_from:
   - /continuous-integration/run-a-command-in-the-background/
 ---
 
-<div class="info-block">
+{% csnote info %}
 This article is about running a service or a command in the background of your CI/CD pipeline with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
-</div>
-
-* include a table of contents
-{:toc}
+{% endcsnote %}
 
 ## Running A Command In The Background
 

--- a/_basic/databases/cassandra.md
+++ b/_basic/databases/cassandra.md
@@ -11,7 +11,7 @@ menus:
     title: Apache Cassandra
     weight: 5
 categories:
-  - Databases    
+  - Databases
 redirect_from:
   - /databases/cassandra/
   - /classic/getting-started/cassandra/
@@ -24,13 +24,13 @@ The latest version from the `2.0.x` release of [Apache Cassandra](http://cassand
 
 To use the service during your builds, start the service via the following command:
 
+{% csnote warning %}
+Note, that this is the only command available via `sudo` and root access to run any other commands is not available on the build VMs.
+{% endcsnote %}
+
 ```shell
 sudo /etc/init.d/cassandra start
 ```
-
-<div class="info-block">
-Note, that this is the only command available via `sudo` and root access to run any other commands is not available on the build VMs.
-</div>
 
 If you require a CLI tool to access or Cassandra server, we would recommend [cqlsh](https://pypi.python.org/pypi/cqlsh) available via pip.
 

--- a/_basic/databases/postgresql.md
+++ b/_basic/databases/postgresql.md
@@ -17,17 +17,17 @@ redirect_from:
   - /databases/postgresql/
   - /classic/getting-started/postgresql/
 categories:
-  - Databases  
+  - Databases
 ---
 
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote warning %}
 PostgreSQL 9.2 officially reached its [end-of-life (EOL)](https://www.postgresql.org/support/versioning) and as a result it was removed from the build environment as of **March 29, 2018**.
 
 PostgreSQL 10 is now the new default running on port 5432.
-</div>
+{% endcsnote %}
 
 PostgreSQL `10` runs on the default port and the credentials are stored in the `PGUSER` and `PGPASSWORD` environment variables. The default databases created for you are **development** and **test**.
 
@@ -41,17 +41,17 @@ You need to activate them with `CREATE EXTENSION` as explained in the [Extension
 
 The **default version** of PostgreSQL on Codeship is **10**, which runs on the default port of `5432`. No additional configuration is required to use version 10.
 
-<div class="info-block">
+{% csnote info %}
 PostgreSQL 10 includes PostGIS version 2.4.
-</div>
+{% endcsnote %}
 
 ### 9.6
 
 PostgreSQL version **9.6** is running on port `5436` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
 
-<div class="info-block">
+{% csnote info %}
 PostgreSQL 9.6 includes PostGIS version 2.3.
-</div>
+{% endcsnote %}
 
 For Rails based projects, please add the following command to your _Setup Commands_ to work around the auto-configuration in place.
 
@@ -63,9 +63,9 @@ sed -i "s|5432|5436|" "config/database.yml"
 
 PostgreSQL version **9.5** is running on port `5435` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
 
-<div class="info-block">
+{% csnote info %}
 PostgreSQL 9.5 includes PostGIS version 2.2.
-</div>
+{% endcsnote %}
 
 For Rails based projects, please add the following command to your _Setup Commands_ to work around the auto-configuration in place.
 
@@ -77,9 +77,9 @@ sed -i "s|5432|5435|" "config/database.yml"
 
 PostgreSQL version **9.4** is running on port `5434` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
 
-<div class="info-block">
+{% csnote info %}
 PostgreSQL 9.4 includes PostGIS version 2.1.
-</div>
+{% endcsnote %}
 
 For Rails based projects, please add the following command to your _Setup Commands_ to work around the auto-configuration in place.
 
@@ -91,9 +91,9 @@ sed -i "s|5432|5434|" "config/database.yml"
 
 PostgreSQL version **9.3** is running on port `5433` and configured (almost) identical to the others. Make sure to specify the correct port in your project configuration if you want to test against this version.
 
-<div class="info-block">
+{% csnote info %}
 PostgreSQL 9.3 includes PostGIS version 2.1.
-</div>
+{% endcsnote %}
 
 For Rails based projects, please add the following command to your _Setup Commands_ to work around the auto-configuration in place.
 

--- a/_basic/databases/rethinkdb.md
+++ b/_basic/databases/rethinkdb.md
@@ -14,7 +14,7 @@ redirect_from:
   - /databases/rethinkdb/
   - /classic/getting-started/rethinkdb/
 categories:
-  - Databases  
+  - Databases
 ---
 
 * include a table of contents
@@ -22,12 +22,12 @@ categories:
 
 RethinkDB is installed on our test VMs but not running by default. To use the RethinkDB during your builds, start the service via the following command:
 
+{% csnote warning %}
+This is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
+{% endcsnote %}
+
 ```shell
 sudo /etc/init.d/rethinkdb start
 ```
-
-<div class="info-block">
-Note, that this is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
-</div>
 
 RethinkDB runs on the default port. Administrative HTTP connections are available via port `50836`.

--- a/_basic/languages-frameworks/nodejs.md
+++ b/_basic/languages-frameworks/nodejs.md
@@ -24,11 +24,11 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about using Node.js with Codeship Basic.
 
 If you'd like to learn more about Codeship Basic, we recommend the [getting started guide]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/basic)
-</div>
+{% endcsnote %}
 
 ## Versions And Setup
 
@@ -101,9 +101,9 @@ export PREFIX="${HOME}/cache/npm/"
 
 ### Scoped Packages
 
-<div class="info-block">
+{% csnote info %}
 Scoped packages are only available for versions of `npm` greater than 2.7.0.
-</div>
+{% endcsnote %}
 
 To create a scoped package, you simply use a package name that starts with your scope.
 

--- a/_basic/services/elasticsearch.md
+++ b/_basic/services/elasticsearch.md
@@ -12,7 +12,7 @@ redirect_from:
   - /services/elasticsearch/
   - /classic/getting-started/elasticsearch/
 categories:
-  - Services  
+  - Services
 ---
 
 * include a table of contents
@@ -20,13 +20,13 @@ categories:
 
 [Elasticsearch](https://www.elastic.co) **1.2.2** is installed on the default port **9200** and doesn't require any credentials. However, it is not running by default. To use Elasticsearch during your builds, start the service with the following command:
 
+{% csnote warning %}
+This is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
+{% endcsnote %}
+
 ```shell
 sudo /etc/init.d/elasticsearch start
 ```
-
-<div class="info-block">
-Note, this is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
-</div>
 
 ## Other Versions
 

--- a/_general/integrations/appranix.md
+++ b/_general/integrations/appranix.md
@@ -11,7 +11,7 @@ menus:
     title: Using Appranix
     weight: 15
 categories:
-  - Integrations    
+  - Integrations
 ---
 
 * include a table of contents
@@ -82,16 +82,16 @@ To start, you need to add the following environment variables to the [encrypted 
 
 To use Appranix, you will need to call your `appranix.sh` script from your [codeship-steps.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}) after the step where your deployment takes place.
 
-```yaml  
+```yaml
 - name: Appranix deployment
   tag: master
   service: app
   command: sh appranix.sh
 ```
 
-<div class="info-block">
-Note: The container must have [Ruby version 2.3.3]({{ site.baseurl }}{% link _pro/languages-frameworks/ruby.md %}) or higher for the `appranix.sh` file to execute the required gem install.
-</div>
+{% csnote info %}
+The container must have [Ruby version 2.3.3]({{ site.baseurl }}{% link _pro/languages-frameworks/ruby.md %}) or higher for the `appranix.sh` file to execute the required gem install.
+{% endcsnote %}
 
 ## Codeship Basic
 
@@ -152,6 +152,6 @@ To use Appranix, you will need to call your `appranix.sh` script from your [depl
 
 After that add `sh appranix.sh` at the end. The script file will connect to Appranix and trigger deployment for the new build.
 
-<div class="info-block">
-Note: Make sure you have selected [Ruby version 2.3.3]({{ site.baseurl }}{% link _basic/languages-frameworks/ruby.md %}). or higher.
-</div>
+{% csnote info %}
+Make sure you have selected [Ruby version 2.3.3]({{ site.baseurl }}{% link _basic/languages-frameworks/ruby.md %}). or higher.
+{% endcsnote %}

--- a/_general/integrations/codeclimate.md
+++ b/_general/integrations/codeclimate.md
@@ -15,7 +15,7 @@ menus:
     title: Using Code Climate
     weight: 1
 categories:
-  - Integrations    
+  - Integrations
 redirect_from:
   - /basic/continuous-integration/code-climate/
   - /pro/continuous-integration/codeclimate-docker/
@@ -24,9 +24,10 @@ redirect_from:
   -  /basic/analytics/code-climate/
 ---
 
-<div class="info-block">
-**Note** that these instructions use the newest version of the Code Climate reporter, which is still in beta. Please view [their documentation](https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage-older-versions) for instructions on using the older reporter. You will still need to add your API token via [encrypted environment variables]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}), as seen below, but the test configuration will work differently.
-</div>
+
+{% csnote info %}
+These instructions use the newest version of the Code Climate reporter, which is still in beta. Please view [their documentation](https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage-older-versions) for instructions on using the older reporter. You will still need to add your API token via [encrypted environment variables]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}), as seen below, but the test configuration will work differently.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_general/integrations/depfu.md
+++ b/_general/integrations/depfu.md
@@ -26,10 +26,9 @@ Depfu continuously updates your dependencies one gem at a time and creates a pul
 
 Starting with Depfu and Codeship is fast and easy. [The Depfu documentation](https://depfu.com/docs) does a great job of providing more information about how to set up Depfu itself, in addition to the instructions below.
 
-<div class="info-block">
-**Note** that at the moment Depfu only works with Ruby projects hosted on GitHub. Support for more languages and other SCMs is planned.
-</div>
-
+{% csnote info %}
+At the moment Depfu only works with Ruby projects hosted on GitHub. Support for more languages and other SCMs is planned.
+{% endcsnote %}
 
 ## Codeship Pro
 

--- a/_general/integrations/rancher.md
+++ b/_general/integrations/rancher.md
@@ -6,7 +6,7 @@ tags:
   - orchestration
   - containers
 categories:
-  - Integrations  
+  - Integrations
 menus:
   general/integrations:
     title: Using Rancher
@@ -18,11 +18,11 @@ menus:
 
 ## About Racher
 
-<div class="info-block">
-Note that Rancher only integrates with [Codeship Pro](https://codeship.com/features/pro) and will not work with [Codeship Basic](https://codeship.com/features/basic).
+{% csnote info %}
+Rancher only integrates with [Codeship Pro](https://codeship.com/features/pro) and will not work with [Codeship Basic](https://codeship.com/features/basic).
 
 If you do not have a familiarity with Codeship Pro, we recommend watching this [introductory webinar](https://resources.codeship.com/webinars/env-parity-docker-codeship-jet) before proceeding with your Rancher setup.
-</div>
+{% endcsnote %}
 
 Rancher is a container management platform that helps bridge the gap between container stacks and infrastructure platforms.
 

--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -22,9 +22,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 If your builds are not getting triggered on Codeship, it could be that we are experiencing a service interruption. Be sure to check our [status page](http://codeshipstatus.com) to monitor any potential issues. You can also follow the [@CodeshipStatus](https://twitter.com/codeship) account on Twitter.
-</div>
+{% endcsnote %}
 
 ## Webhooks
 

--- a/_general/projects/getting-started.md
+++ b/_general/projects/getting-started.md
@@ -75,11 +75,11 @@ A user with appropriate permission for the target account needs to confirm the t
 
 If you want to **bulk transfer projects**, please reach out to our support via [helpdesk.codeship.com](https://helpdesk.codeship.com).
 
-<div class="info-block">
-**Use Case Examples**
+{% csnote  %}
+**Example Use Cases**
 * You are using the Heroku addon and want to start using Codeship without it.
 * You don't want to maintain a project anymore and want to transfer it to someone else.
-</div>
+{% endcsnote %}
 
 ## Limit Builds to Specific Branches
 We don’t have a feature to limit which branches can be built.

--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,9 +1,10 @@
 {% assign words = content | number_of_words %}
 
-<div class="reading-block" title="Estimated read time">
+
+{% csnote time %}
   {% if words < 360 %}
-    <p>You'll need about one minute to read this article.</p>
+    <p>You will need about one minute to read this article.</p>
   {% else %}
-		<p>You'll need roughly {{ words | divided_by:180 }} minutes to read this article.</p>
+		<p>You will need roughly {{ words | divided_by:180 }} minutes to read this article.</p>
   {% endif %}
-</div>
+{% endcsnote %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,14 +33,13 @@ layout: default
         {{ content }}
       </div>
 
-      <div class="feedback-block">
-				<h2>Need more help?</h2>
+      {% csnote %}
+				<h4>Need more help?</h4>
 
-				<p>You can post on <a href="http://stackoverflow.com/questions/ask?tags=codeship" target="_BLANK">Stack Overflow</a> using the tag <code>#codeship</code> or <a href="https://helpdesk.codeship.com">contact our Helpdesk</a>.</p>
+				<p>You can post on <a href="http://stackoverflow.com/questions/ask?tags=codeship" target="_BLANK">Stack Overflow</a> using the tag <code>#codeship</code> or <a href="https://helpdesk.codeship.com">contact our Helpdesk</a>.<br />
+				We also have a couple of <a href="https://github.com/codeship-library" target="_BLANK">code examples and sample projects</a> available for you to get started with.</p>
 
-				<p>We also have a couple of <a href="https://github.com/codeship-library" target="_BLANK">code examples and sample projects</a> available.</p>
-
-        <h2>Was This Article Helpful?</h2>
+        <h4>Was This Article Helpful?</h4>
         <div id="pd_rating_holder_8520732" class="polldaddy"></div>
         <script type="text/javascript">
 	        PDRTJS_settings_8520732 = {
@@ -51,8 +50,9 @@ layout: default
 	        };
 	        (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
         </script>
-        <div class="feedback"><p><a href="https://codeship.wufoo.com/forms/z12bkuf0eyp5qx/def/field3={{ page.title }}" target=_"BLANK">Please submit this feedback form to help us improve this article!</a></p></div>
-      </div>
+
+				<p>Do you think we need to improve this article? If so, please <a href="https://codeship.wufoo.com/forms/z12bkuf0eyp5qx/def/field3={{ page.title }}" target=_"BLANK">submit our feedback form</a> to help us improve this article!</p>
+      {% endcsnote %}
     </div>
   </div>
 </div>

--- a/_plugins/ConcatArrays.rb
+++ b/_plugins/ConcatArrays.rb
@@ -1,8 +1,0 @@
-module Jekyll
-  module ConcatFilter
-    def concat(one, two)
-      one.concat(two)
-    end
-  end
-end
-Liquid::Template.register_filter(Jekyll::ConcatFilter)

--- a/_plugins/note_tag.rb
+++ b/_plugins/note_tag.rb
@@ -1,0 +1,22 @@
+module Jekyll
+	class NoteTag < Liquid::Block
+		def initialize(tag_name, type, tokens)
+			super
+			@type = type.strip.downcase unless type.empty?
+		end
+
+		def render(context)
+			content = super
+			css_classes = "note-#{@type}" if @type
+
+			out = <<~EOF
+				<div class="note #{css_classes}">
+					#{content}
+				</div>
+			EOF
+			out
+		end
+	end
+end
+
+Liquid::Template.register_tag('csnote', Jekyll::NoteTag)

--- a/_pro/builds-and-configuration/build-arguments.md
+++ b/_pro/builds-and-configuration/build-arguments.md
@@ -27,15 +27,14 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
-This article is about using Docker build arguments with Codeship Pro.
 
- If you are unfamiliar with build arguments, we recommend reading [Docker's build arguments documentation](https://docs.docker.com/engine/reference/builder/#arg).
+{% csnote info %}
+This article is about using Docker build arguments with Codeship Pro. If you are unfamiliar with build arguments, we recommend reading [Docker's build arguments documentation](https://docs.docker.com/engine/reference/builder/#arg). If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+{% endcsnote %}
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
-
- Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}) to encrypt your build arguments.
-</div>
+{% csnote %}
+Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}) to encrypt your build arguments.
+{% endcsnote %}
 
 ## Overview: Build Arguments
 
@@ -97,9 +96,9 @@ In a lot of cases, the values needed by the image at build time are secrets -- c
 
 First, create a file in the root directory - in this case, a file named `build_args`. You will also need to [download the project AES key]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}#downloading-your-aes-key) to the root directory (and add it to the `.gitignore` file).
 
-<div class="info-block">
+{% csnote info %}
 If you need to reset your AES key you can do so by visiting _Project Settings_ > _General_ and clicking _Reset project AES key_.
-</div>
+{% endcsnote %}
 
 ```shell
 GEM_SERVER_TOKEN=XXXXXXXXXXXX

--- a/_pro/builds-and-configuration/caching.md
+++ b/_pro/builds-and-configuration/caching.md
@@ -23,9 +23,9 @@ redirect_from:
   - /pro/getting-started/caching/
 ---
 
-<div class="info-block">
+{% csnote info %}
 This tutorial describes the way caching works on Codeship's infrastructure during a build. For [local builds using the `jet` CLI]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}), rely on the local Docker image cache.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/builds-and-configuration/cloning-repos.md
+++ b/_pro/builds-and-configuration/cloning-repos.md
@@ -23,9 +23,9 @@ redirect_from:
   - /pro/getting-started/cloning-repos/
 ---
 
-<div class="info-block">
+{% csnote info %}
 To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/builds-and-configuration/docker-volumes.md
+++ b/_pro/builds-and-configuration/docker-volumes.md
@@ -20,9 +20,9 @@ redirect_from:
   - /pro/getting-started/docker-volumes/
 ---
 
-<div class="info-block">
+{% csnote info %}
 To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/builds-and-configuration/environment-variables.md
+++ b/_pro/builds-and-configuration/environment-variables.md
@@ -24,13 +24,13 @@ redirect_from:
   - /pro/getting-started/environment-variables
 ---
 
-<div class="info-block">
+{% csnote info %}
 This article is about using environment variables with Codeship Pro.
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
- Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}) to encrypt your environment variables.
-</div>
+Note that you will also need to use the [Codeship Pro local CLI tool]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}) to encrypt your environment variables.
+{% endcsnote %}
 
 
 * include a table of contents
@@ -81,9 +81,9 @@ Navigate to _Project Settings_ > _General_ and you'll find a section labeled _AE
 
 Save that file as `codeship.aes` in your repository root and don't forget to add the key to your `.gitignore` file so you don't accidentally commit it to your repository.
 
-<div class="info-block">
+{% csnote info %}
 If you need to reset your AES key you can do so by visiting _Project Settings_ > _General_ and clicking _Reset project AES key_.
-</div>
+{% endcsnote %}
 
 ### Encrypting Your Environment Variables
 

--- a/_pro/builds-and-configuration/handling-secrets.md
+++ b/_pro/builds-and-configuration/handling-secrets.md
@@ -96,6 +96,6 @@ For any secret that needs to be accessed during container runtime, meaning _afte
 
 You'll need to [download Jet]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}), the CLI for running Codeship Pro builds locally, as well as [grab your project's AES key]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}#downloading-your-aes-key) from the Project Settings page.
 
-<div class="info-block">
+{% csnote info %}
 If you need to reset your AES key you can do so by visiting _Project Settings_ > _General_ and clicking _Reset project AES key_.
-</div>
+{% endcsnote %}

--- a/_pro/builds-and-configuration/image-registries.md
+++ b/_pro/builds-and-configuration/image-registries.md
@@ -32,9 +32,9 @@ redirect_from:
   - /docker/getting-started/docker-push/
 ---
 
-<div class="info-block">
-To follow this tutorial on your own computer, please [install the `jet` CLI locally first]({{ site.baseurl }}{% link _pro/jet-cli/usage-overview.md %}).
-</div>
+{% csnote info %}
+If you need to reset your AES key you can do so by visiting _Project Settings_ > _General_ and clicking _Reset project AES key_.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/builds-and-configuration/services.md
+++ b/_pro/builds-and-configuration/services.md
@@ -25,13 +25,13 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about the `codeship-services.yml` file that powers Codeship Pro.
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
- Also note that the `codeship-services.yml` file depends on the `codeship-steps.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}).
-</div>
+Also note that the `codeship-services.yml` file depends on the `codeship-steps.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}).
+{% endcsnote %}
 
 ## What Is Your Codeship Services File?
 Your services file - `codeship-services.yml` - is where you configure each service you need to run your CI/CD builds with Codeship. During the build, these services will be used to run the testing steps you've defined in your `codeship-steps.yml` [file]({% link _pro/builds-and-configuration/steps.md %}). You can have as many services as you'd like, and customize each of them. Each of these services will be run inside a Docker container.

--- a/_pro/builds-and-configuration/steps.md
+++ b/_pro/builds-and-configuration/steps.md
@@ -27,13 +27,13 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 This article is about the `codeship-steps.yml` file that powers Codeship Pro.
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
- Also note that the `codeship-steps.yml` file depends on the `codeship-services.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}).
-</div>
+Also note that the `codeship-steps.yml` file depends on the `codeship-services.yml` file, which you can [learn more about here]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}).
+{% endcsnote %}
 
 ## What Is codeship-steps.yml?
 
@@ -197,10 +197,9 @@ Run steps specify a command to run on a service. You must specify one or two dir
 
 ## Push steps
 
-<br />
-<div class="info-block">
+{% csnote info %}
 We implemented tagging via templates. See below for the available variables. Did we miss any important ones? Let us know at [support@codeship.com](mailto:support@codeship.com).
-</div>
+{% endcsnote %}
 
 Push steps allow a generated container to be pushed to a remote docker registry. When running after a build, this allows a deployment based upon the successful build to occur. You must specify a number of directives:
 
@@ -269,7 +268,7 @@ You can use the `on_fail` directive to specify one or more commands to run if a 
   command: true
   on_fail:
     - command: notify-fail.sh
-```      
+```
 
 It is important to note that steps that run on failure inherit the service of the step that failed.
 

--- a/_pro/continuous-deployment/aws-codedeploy.md
+++ b/_pro/continuous-deployment/aws-codedeploy.md
@@ -6,7 +6,7 @@ menus:
     title: AWS CodeDeploy
     weight: 5
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - aws
@@ -17,9 +17,9 @@ tags:
 
 ---
 
-<div class="info-block">
-You can find a sample repo for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
-</div>
+{% csnote info %}
+You can find a [sample repo for deploying to AWS with Codeship Pro](https://github.com/codeship-library/aws-utilities) on Github.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/aws-ecs.md
+++ b/_pro/continuous-deployment/aws-ecs.md
@@ -6,7 +6,7 @@ menus:
     title: AWS ECS
     weight: 4
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - aws
@@ -18,9 +18,9 @@ tags:
 
 ---
 
-<div class="info-block">
-You can find a sample repo for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
-</div>
+{% csnote info %}
+You can find a [sample repo for deploying to AWS with Codeship Pro](https://github.com/codeship-library/aws-utilities) on Github.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/aws-elasticbeanstalk.md
+++ b/_pro/continuous-deployment/aws-elasticbeanstalk.md
@@ -6,7 +6,7 @@ menus:
     title: AWS EB
     weight: 3
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - aws
@@ -16,9 +16,9 @@ tags:
 
 ---
 
-<div class="info-block">
-You can find a sample repo for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
-</div>
+{% csnote info %}
+You can find a [sample repo for deploying to AWS with Codeship Pro](https://github.com/codeship-library/aws-utilities) on Github.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/aws-s3.md
+++ b/_pro/continuous-deployment/aws-s3.md
@@ -6,7 +6,7 @@ menus:
     title: AWS S3
     weight: 2
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - aws
@@ -16,9 +16,9 @@ tags:
 
 ---
 
-<div class="info-block">
-You can find a sample repo for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
-</div>
+{% csnote info %}
+You can find a [sample repo for deploying to AWS with Codeship Pro](https://github.com/codeship-library/aws-utilities) on Github.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/aws.md
+++ b/_pro/continuous-deployment/aws.md
@@ -6,7 +6,7 @@ menus:
     title: AWS
     weight: 1
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - aws
@@ -19,13 +19,13 @@ redirect_from:
   - /docker-integration/aws/
 ---
 
-<div class="info-block">
+{% csnote info %}
 This article is about deploying to AWS using Codeship Pro.
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
-You can find a sample repository for deploying to AWS with Codeship Pro on Github [here](https://github.com/codeship-library/aws-utilities).
-</div>
+You can find a [sample repo for deploying to AWS with Codeship Pro](https://github.com/codeship-library/aws-utilities) on Github.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/azure.md
+++ b/_pro/continuous-deployment/azure.md
@@ -16,9 +16,10 @@ tags:
   - Docker
 
 ---
-<div class="info-block">
+
+{% csnote info %}
 You can find a sample repo for deploying to the Azure Container Service with Codeship Pro on Github [here](https://github.com/codeship-library/azure-utilities).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/docker-swarm.md
+++ b/_pro/continuous-deployment/docker-swarm.md
@@ -6,16 +6,16 @@ menus:
     title: Docker Swarm
     weight: 15
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - swarm
   - docker
 ---
 
-<div class="info-block">
+{% csnote info %}
 You can find a sample repository for deploying with Docker Swarm and Codeship Pro on Github [here](https://github.com/codeship-library/example-voting-app).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/google-cloud.md
+++ b/_pro/continuous-deployment/google-cloud.md
@@ -19,9 +19,9 @@ redirect_from:
   - /docker/continuous-deployment/google-cloud/
 ---
 
-<div class="info-block">
+{% csnote info %}
 You can find a sample repo for deploying to Google Cloud with Codeship Pro on Github [here](https://github.com/codeship-library/google-cloud-deployment).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}
@@ -66,9 +66,9 @@ GOOGLE_PROJECT_ID=...
 
 - `GOOGLE_PROJECT_ID` should be populated with the value found on the Dashboard of your project in the Google developer console.
 
-<div class="alert-block">
+{% csnote warning %}
 Be sure to put this unencrypted env file into `.gitignore` so its never committed, or delete it altogether following encryption.
-</div>
+{% endcsnote %}
 
 After creating this environment variables file, you will need to encrypt it using the instructions from our [encrypted environment variables tutorial]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}) or by using the commands below:
 

--- a/_pro/continuous-deployment/google-container.md
+++ b/_pro/continuous-deployment/google-container.md
@@ -15,9 +15,9 @@ tags:
   - docker
 ---
 
-<div class="info-block">
+{% csnote info %}
 You can find a sample repo for deploying to Google Cloud with Codeship Pro on Github [here](https://github.com/codeship-library/google-cloud-deployment).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}
@@ -62,9 +62,9 @@ GOOGLE_PROJECT_ID=...
 
 - `GOOGLE_PROJECT_ID` should be populated with the value found on the Dashboard of your project in the Google developer console.
 
-<div class="alert-block">
+{% csnote warning %}
 Be sure to put this unencrypted env file into `.gitignore` so its never committed, or delete it altogether following encryption.
-</div>
+{% endcsnote %}
 
 After creating this environment variables file, you will need to encrypt it using the instructions from our [encrypted environment variables tutorial]({{ site.baseurl }}{% link _pro/builds-and-configuration/environment-variables.md %}) or by using the commands below:
 

--- a/_pro/continuous-deployment/heroku.md
+++ b/_pro/continuous-deployment/heroku.md
@@ -10,18 +10,18 @@ tags:
   - heroku
   - docker
 categories:
-  - Continuous Deployment    
+  - Continuous Deployment
 redirect_from:
   - /docker-integration/heroku/
 ---
 
-<div class="info-block">
+{% csnote info %}
 This article is about deploying to Heroku using Codeship Pro.
 
- If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/getting-started.md %}) or [the features overview page](http://codeship.com/features/pro).
 
 You can find a sample repository for deploying to Heroku with Codeship Pro on Github [here](https://github.com/codeship-library/heroku-deployment).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/ibm-bluemix-cloudfoundry.md
+++ b/_pro/continuous-deployment/ibm-bluemix-cloudfoundry.md
@@ -6,7 +6,7 @@ menus:
     title: IBM Cloud Foundry
     weight: 16
 categories:
-  - Continuous Deployment        
+  - Continuous Deployment
 tags:
   - deployment
   - ibm
@@ -16,9 +16,9 @@ tags:
   - blue mix
 
 ---
-<div class="info-block">
+{% csnote info %}
 You can find a sample repo for deploying to IBM Cloud with Codeship Pro on Github [here](https://github.com/codeship-library/ibm-bluemix-utilities).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/continuous-deployment/ibm-bluemix-container-service.md
+++ b/_pro/continuous-deployment/ibm-bluemix-container-service.md
@@ -6,7 +6,7 @@ menus:
     title: IBM Cloud Container Service
     weight: 17
 categories:
-  - Continuous Deployment   
+  - Continuous Deployment
 tags:
   - deployment
   - ibm
@@ -15,9 +15,9 @@ tags:
   - blue mix
 
 ---
-<div class="info-block">
+{% csnote info %}
 You can find a sample repo for deploying to IBM Cloud with Codeship Pro on Github [here](https://github.com/codeship-library/ibm-bluemix-utilities).
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}
@@ -100,7 +100,7 @@ Note that in this example, all of the Container Service deployment commands have
   type: push
   image_name: registry.ng.bluemix.net/your-org/your-image
   registry: registry.ng.bluemix.net
-  dockercfg_service: dockercfg_generator  
+  dockercfg_service: dockercfg_generator
 
 - name: IBM Cloud Container Service Kubernetes Deployment
   service: deployment

--- a/_pro/continuous-deployment/ssh-deploy.md
+++ b/_pro/continuous-deployment/ssh-deploy.md
@@ -21,9 +21,9 @@ categories:
   - Continuous Deployment
 ---
 
-<div class="info-block">
+{% csnote info %}
 See the [example repo](https://github.com/codeship-library/docker-utilities/tree/master/ssh-helper) for a full example and further instructions on using SSH and SCP with Codeship Pro.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/jet-cli/release-notes.md
+++ b/_pro/jet-cli/release-notes.md
@@ -19,6 +19,6 @@ redirect_from:
   - /pro/builds-and-configuration/release-notes/
 ---
 
-<div class="info-block">
+{% csnote info %}
 Missing versions only improved the integration with our hosted platform and have no user facing changes / bug fixes.
-</div>
+{% endcsnote %}

--- a/_pro/jet-cli/usage-overview.md
+++ b/_pro/jet-cli/usage-overview.md
@@ -28,11 +28,11 @@ redirect_from:
   - /pro/builds-and-configuration/cli/
 ---
 
-<div class="info-block">
-  <p>If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/quickstart-examples.md %}) or [the features overview page](http://codeship.com/features/pro).</p>
+{% csnote info %}
+If you are unfamiliar with Codeship Pro, we recommend our [getting started guide]({{ site.baseurl }}{% link _pro/quickstart/quickstart-examples.md %}) or [the features overview page](http://codeship.com/features/pro).
 
-  <p>Note that if you are using Codeship Basic, you will not be able to use the local CLI.</p>
-</div>
+Note that if you are using Codeship Basic, you will not be able to use the local CLI.
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/elixir.md
+++ b/_pro/languages-frameworks/elixir.md
@@ -15,9 +15,9 @@ redirect_from:
   - /docker-integration/elixir/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/go.md
+++ b/_pro/languages-frameworks/go.md
@@ -15,9 +15,9 @@ redirect_from:
   - /docker-integration/go/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/java.md
+++ b/_pro/languages-frameworks/java.md
@@ -16,9 +16,9 @@ redirect_from:
   - /docker-integration/java/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/nodejs.md
+++ b/_pro/languages-frameworks/nodejs.md
@@ -18,9 +18,9 @@ redirect_from:
   - /docker-integration/nodejs/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/php.md
+++ b/_pro/languages-frameworks/php.md
@@ -17,9 +17,9 @@ redirect_from:
   - /docker-integration/php/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/python.md
+++ b/_pro/languages-frameworks/python.md
@@ -17,9 +17,9 @@ redirect_from:
   - /docker-integration/python/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/languages-frameworks/ruby.md
+++ b/_pro/languages-frameworks/ruby.md
@@ -17,9 +17,9 @@ redirect_from:
   - /docker-integration/ruby/
 ---
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 * include a table of contents
 {:toc}

--- a/_pro/quickstart/docker-101.md
+++ b/_pro/quickstart/docker-101.md
@@ -6,7 +6,7 @@ menus:
     title: Docker For CI/CD
     weight: 3
 categories:
-  - Quickstart    
+  - Quickstart
 tags:
   - docker
   - jet
@@ -18,9 +18,9 @@ tags:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 We've got [quickstart repos, sample apps and a getting started guide]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 Because Codeship Pro uses Docker domain language, and is powered by Docker, most customers find it easier to use if they are familiar with Docker concepts.
 

--- a/_pro/quickstart/getting-started-part-five.md
+++ b/_pro/quickstart/getting-started-part-five.md
@@ -3,7 +3,7 @@ title: Codeship Pro Introduction Guide Part 5
 tags:
   - docker
   - jet
-  - codeship pro  
+  - codeship pro
   - introduction
   - getting started
   - tutorial
@@ -18,9 +18,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 In addition to this guide, we've also got [quickstart repos and sample apps]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via
 

--- a/_pro/quickstart/getting-started-part-four.md
+++ b/_pro/quickstart/getting-started-part-four.md
@@ -4,7 +4,7 @@ layout: page
 tags:
   - docker
   - jet
-  - codeship pro  
+  - codeship pro
   - introduction
   - getting started
   - tutorial
@@ -19,9 +19,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 In addition to this guide, we've also got [quickstart repos and sample apps]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via
 

--- a/_pro/quickstart/getting-started-part-three.md
+++ b/_pro/quickstart/getting-started-part-three.md
@@ -19,9 +19,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 In addition to this guide, we've also got [quickstart repos and sample apps]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via
 
@@ -112,11 +112,11 @@ docker login
 cat ${HOME}/.docker/config.json
 ```
 
-<div class="info-block">
-**Note that if you are using Mac OSX**, the newer versions of Docker have changed to store credentials in the OSX keychain rather than in a configuration file.
+{% csnote info %}
+**If you are using Mac OSX**, the newer versions of Docker have changed to store credentials in the OSX keychain rather than in a configuration file.
 
 To get the appropriate authentication file on OSX, you will need to remove the `credsStore` line from Docker's `config.json` to disable Keychain storage, re-run `docker login` and then use the values it then generates in your updated `dockercfg` as shown above.
-</div>
+{% endcsnote %}
 
 This will print the `auths` value that we need to add to our `dockercfg` file. Once we've added this information to our `dockercfg` file and saved it, we'll run:
 

--- a/_pro/quickstart/getting-started-part-two.md
+++ b/_pro/quickstart/getting-started-part-two.md
@@ -4,7 +4,7 @@ layout: page
 tags:
   - docker
   - jet
-  - codeship pro  
+  - codeship pro
   - introduction
   - getting started
   - tutorial
@@ -19,9 +19,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 In addition to this guide, we've also got [quickstart repos and sample apps]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 The source for the tutorial is available on Github as [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via
 

--- a/_pro/quickstart/getting-started.md
+++ b/_pro/quickstart/getting-started.md
@@ -19,9 +19,9 @@ redirect_from:
 * include a table of contents
 {:toc}
 
-<div class="info-block">
+{% csnote info %}
 In addition to this guide, we've also got [quickstart repos and sample apps]({% link _pro/quickstart/quickstart-examples.md %}) available to make starting out with Codeship Pro faster and easier.
-</div>
+{% endcsnote %}
 
 The source for the tutorial is available on GitHub at [codeship/ci-guide](https://github.com/codeship/ci-guide/) and you can clone it via
 

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -296,141 +296,35 @@ div#integrations {
 // Notification Blocks
 // *******************************************************
 
-.alert-block,
-.feedback-block,
-.info-block,
-.reading-block {
-  position: relative;
-  padding: 1rem 1rem 1rem 2.5rem;
-  line-height: 1.2em;
-  border: 1px solid #fff;
-  border-radius: 4px;
-  color: #313a44;
-  margin: 1.5em 0;
-
+.note {
   > *:first-child::before {
     font-family: 'FontAwesome';
-    color: #fff;
-    margin-left: -1.5em;
-    padding-right: .5em;
-  }
-
-  h2 {
-    font: bolder 20px/1.6 "Lato", sans-serif;
-    margin: 1.2em 0 .8em;
-    color: #313a44;
+    content: '';
   }
 
   p {
-    font: 300 16px/1.6 "museo-sans-rounded", Arial, sans-serif;
-    margin: .2em 0;
-  }
-
-  a {
-    color: #1e252c;
-    font-size: 1em;
-    margin: 0;
-    text-decoration: underline;
-  }
-
-  code {
-    color: $blue-darkest;
-    background-color: $blue-light;
-    border-color: $blue;
+    margin-bottom: 0;
   }
 }
 
-.alert-block {
-  background-color: $yellow-lightest;
-  border-color: $yellow-lightest;
-
+.note-info {
   > *:first-child::before {
-    content: '\f071';
-    color: $yellow-darkest;
-  }
-
-  a {
-    color: $yellow-darkest;
-  }
-
-  code {
-    color: $yellow-darkest;
-    background-color: $yellow-light;
-    border-color: $yellow;
+    content: '\f05a\00a0';
   }
 }
-
-.info-block {
-  background-color: $blue-lightest;
-  border-color: $blue-lightest;
-
+.note-warning {
   > *:first-child::before {
-    content: '\f05a';
-    color: $blue-darkest;
-  }
-
-  a {
-    color: $blue-darkest;
-  }
-
-  code {
-    color: $blue-darkest;
-    background-color: $blue-light;
-    border-color: $blue;
-  }
-
-}
-
-.feedback-block {
-  padding-top: .1em;
-  background-color: $gray-lightest;
-  border-color: $gray-lightest;
-
-  > *:first-child::before {
-    content: '\f059';
-    color: $gray-darkest;
-  }
-
-  a {
-    color: $gray-darkest;
-  }
-
-  p {
-    margin-top: 1rem;
-  }
-
-  .feedback {
-
-    p {
-      margin-top: 2rem;
-      font-weight: bold;
-      font-style: italic;
-    }
-
-  }
-
-  code {
-    color: $gray-darkest;
-    background-color: $gray-light;
-    border-color: $gray;
-  }
-
-  .rating-nero-value {
-    margin-right: 2em;
+    content: '\f071\00a0';
   }
 }
-
-.reading-block {
-  background-color: #fff;
-  border-color: #fff;
-  color: #788594;
-  margin: 0 0 .8em;
-  padding-top: 0;
-  padding-bottom: 0;
-
+.note-success {
   > *:first-child::before {
-    content: '\f017';
-    color: #788594;
+    content: '\f14a\00a0';
+  }
+}
+.note-time {
+  > *:first-child::before {
+    content: '\f017\00a0';
   }
 }
 

--- a/_sass/docs/_page.scss
+++ b/_sass/docs/_page.scss
@@ -312,16 +312,19 @@ div#integrations {
     content: '\f05a\00a0';
   }
 }
+
 .note-warning {
   > *:first-child::before {
     content: '\f071\00a0';
   }
 }
+
 .note-success {
   > *:first-child::before {
     content: '\f14a\00a0';
   }
 }
+
 .note-time {
   > *:first-child::before {
     content: '\f017\00a0';


### PR DESCRIPTION
We were previously using a custom component for `info` (and similar) blocks, but [Shipyard](https://codeship.github.io/shipyard/) has since added a [Note component](https://codeship.github.io/shipyard/components/notes) that fits our needs.

This PR makes a `csnote` helper available, that optionally takes a single argument detailing which type of note is used:

* `{% csnote %}...{% endcsnote %}` for a standard (grey) note
* `{% csnote info %}...{% endcsnote %}` for a info (blue) note
* `{% csnote success %}...{% endcsnote %}` for a success (green) note
* `{% csnote warning %}...{% endcsnote %}` for a warning (yellow) note

Info, Success and Warning notes are customized with additional icons to make it easier to distinguish those UI elements and not rely on color alone.

Staging deployment is available at https://documentation.codeship.com/staging/blocks-v1.1/

## Screenshots

### Standard Note

![](https://d.pr/i/Qh4NlA+)

### Info Note

![](https://d.pr/i/nm46d8+)

### Success Note

(currently not in use)

### Warning Note

![](https://d.pr/i/pw9wto+)