### PR TITLE
Docker 18.03

### DIFF
--- a/_data/docker.yml
+++ b/_data/docker.yml
@@ -1,1 +1,2 @@
-version: "17.10"
+latest_update: '2018/05/04'
+version: "18.03"

--- a/_pro/builds-and-configuration/services.md
+++ b/_pro/builds-and-configuration/services.md
@@ -145,9 +145,9 @@ data:
     - ./tmp/data:/data
 ```
 
-**Note**: volumes should only be mounted from a relative path, as the hosts are ephemeral, and you should not rely on existence of certain directories. Although absolute paths are possible at the moment, we will remove support for them soon.
-
-[Learn more about using volumes.]({{ site.baseurl }}{% link _pro/builds-and-configuration/docker-volumes.md %})
+{% csnote warning %}
+Volumes should only be mounted from a relative path, as the hosts are ephemeral, and you should not rely on existence of certain directories. Although absolute paths are possible at the moment, we will remove support for them soon. [Learn more about using volumes.]({{ site.baseurl }}{% link _pro/builds-and-configuration/docker-volumes.md %})
+{% endcsnote %}
 
 ### HEALTHCHECK
 
@@ -176,7 +176,9 @@ Or, inside of your Dockerfile:
 FROM healthcheck/postgres:alpine
 ```
 
-**Note** that Docker will fail a build that makes three unsuccessful attempts to poll for a healthy state, by default. This can be problematic when using options such as `--interval`, which instruct Docker to poll at a different rate than it's default 30 seconds. You can also change the number of retries Docker tolerates with the `--retries` option.
+{% csnote info %}
+Docker will fail a build that makes three unsuccessful attempts to poll for a healthy state, by default. This can be problematic when using options such as `--interval`, which instruct Docker to poll at a different rate than it's default 30 seconds. You can also change the number of retries Docker tolerates with the `--retries` option.
+{% endcsnote %}
 
 ### Environment Variables
 


### PR DESCRIPTION
Update docs to reflect that we are now using Docker v18.03 for Codeship Pro. 

Also update to _Note_ paragraphs to use the `csnote` helper instead.