### PR TITLE
Letting category pages have titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ zendesk:
   chat: false
 
 # SEO Tag
-title: Codeship Documentation
 twitter:
   username: codeship
 facebook:

--- a/_layouts/categories-default.html
+++ b/_layouts/categories-default.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+	{% include head.html %}
+	<title>Codeship {{ page.category }} Support Information</title>
+</head>
+<body class="{{page.bodyclass}}">
+<noscript id="deferred-styles">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
+	<link href="https://fonts.googleapis.com/css?family=Lato:400,900" rel="stylesheet" />
+</noscript>
+	{% include codeship_header.html %}
+	{% include documentation_header.html %}
+
+	<div class="Layout">
+		{% if page.collection %}
+			{% include sidebar.html %}
+		{% endif %}
+
+		<div class="Content">
+			{{ content }}
+		</div>
+	</div>
+
+	{% include footer.html %}
+	{% include segment.html %}
+	{% include hubspot.html %}
+	{% include zendesk.html %}
+</body>
+</html>

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -1,6 +1,5 @@
 ---
-layout: default
-title: Support Information About CI/CD And Codeship
+layout: categories-default
 bodyclass: is-blue
 ---
 {% assign basic = page.documents | where: "collection", "basic" %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,6 @@
 
 	{% include footer.html %}
 	{% include segment.html %}
-	{% include inspectlet.html %}
 	{% include hubspot.html %}
 	{% include zendesk.html %}
 </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
 
 	{% include footer.html %}
 	{% include segment.html %}
-	{% include inspectlet.html %}	
+	{% include inspectlet.html %}
 	{% include hubspot.html %}
 	{% include zendesk.html %}
 </body>


### PR DESCRIPTION
This will likely need some refactoring, but the constraints are:

- The SEO plugin title metadata seems not to be used anywhere, as we have default titles overriding in all cases. So, it's useless and in the case of injecting the title into the header.html it created duplicate <title>s

- Jekly frontmatter is yaml and won't take variables, so the title can't be set on the actual category HTML layout page itself as far as I can figure, has to be one level above in a template