### PR TITLE
add warning that 'jet steps' will only run push steps with --push flag

### DIFF
--- a/_pro/builds-and-configuration/steps.md
+++ b/_pro/builds-and-configuration/steps.md
@@ -197,10 +197,13 @@ Run steps specify a command to run on a service. You must specify one or two dir
 
 ## Push Steps
 
-<br />
-<div class="info-block">
+{% csnote info %}
 We implemented tagging via templates. See below for the available variables. Did we miss any important ones? Let us know at [support@codeship.com](mailto:support@codeship.com).
-</div>
+{% endcsnote %}
+
+{% csnote warning %}
+Push steps by default will be ignored when run on local machine via `jet steps`. To override, run with flag: `jet steps --push`
+{% endcsnote %}
 
 Push steps allow a generated container to be pushed to a remote docker registry. When running after a build, this allows a deployment based upon the successful build to occur. You must specify a number of directives:
 


### PR DESCRIPTION
User recently pointed out that blocking of push steps via `jet steps` is not noted in our documentation.

![image](https://user-images.githubusercontent.com/1088926/40814674-e1cad620-64fe-11e8-96d5-0c1051149894.png)
