### PR TITLE
Fix redis version discrepancy

### DIFF
--- a/_pro/quickstart/getting-started.md
+++ b/_pro/quickstart/getting-started.md
@@ -206,7 +206,7 @@ And if you scroll through your logs, you should see the versions for *redis* and
 
 Now we'll take a look at one of the cool benefits of doing all of your CI/CD process with these simple files in your repo.
 
-Open up `codeship-services.yml` and find the line where you define your *redis* service. Change `healthcheck/redis:alpine` to `image: redis:3.2.11`.
+Open up `codeship-services.yml` and find the line where you define your *redis* service. Change `image: healthcheck/redis:alpine` to `image: redis:3.2.11`.
 
 ## Run Locally Again
 

--- a/_pro/quickstart/getting-started.md
+++ b/_pro/quickstart/getting-started.md
@@ -206,7 +206,7 @@ And if you scroll through your logs, you should see the versions for *redis* and
 
 Now we'll take a look at one of the cool benefits of doing all of your CI/CD process with these simple files in your repo.
 
-Open up `codeship-services.yml` and find the line where you define your *redis* service. Change `image: redis:3.0.5` to `image: redis:3.2.11`.
+Open up `codeship-services.yml` and find the line where you define your *redis* service. Change `healthcheck/redis:alpine` to `image: redis:3.2.11`.
 
 ## Run Locally Again
 


### PR DESCRIPTION
I was working through Codeship Pro Introduction Guide Part 1 and noticed the change to use the healthcheck Redis image [as described at the top of the guide](https://documentation.codeship.com/pro/quickstart/getting-started/#define-your-services) wasn't propagated to the demonstration at the end.

The guide was asking me find a line that didn't exist, which caused a moment's confusion, so I figured it was worth fixing, and took the path of least resistance. It's not necessarily the most elegant fix, since the fact that we're changing versions isn't quite as clear as it was before using healthcheck images (it used to be `redis:3.0.5`, which called out a version explicitly, so it made sense what was happening when you changed it to `redis:3.2.11`). Regardless, I figured having the image match the first section of the guide and was most important.