### PR TITLE
Fix favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Expires" content="30" />
 
 <link href="{{ site.baseurl }}/assets/css/docs.css" rel="stylesheet" />
-<link rel="shortcut icon" type="image/ico" href="https://codeship.com/favicon.ico" />
+<link rel="shortcut icon" type="image/ico" href="https://app.codeship.com/favicon.ico" />
 
 <!-- SEO metadata -->
 {% seo %}


### PR DESCRIPTION
Favicon is not currently loading I think because the codeship.com favicon redirects to HubSpot. Grabbing it from the Codeship app works instead.