### PR TITLE
removing old references to sudo not being available

### DIFF
--- a/_basic/databases/cassandra.md
+++ b/_basic/databases/cassandra.md
@@ -24,10 +24,6 @@ The latest version from the `2.0.x` release of [Apache Cassandra](https://cassan
 
 To use the service during your builds, start the service via the following command:
 
-{% csnote warning %}
-Note, that this is the only command available via `sudo` and root access to run any other commands is not available on the build VMs.
-{% endcsnote %}
-
 ```shell
 sudo /etc/init.d/cassandra start
 ```

--- a/_basic/databases/rethinkdb.md
+++ b/_basic/databases/rethinkdb.md
@@ -22,10 +22,6 @@ categories:
 
 RethinkDB is installed on our test VMs but not running by default. To use the RethinkDB during your builds, start the service via the following command:
 
-{% csnote warning %}
-This is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
-{% endcsnote %}
-
 ```shell
 sudo /etc/init.d/rethinkdb start
 ```

--- a/_basic/languages-frameworks/dart.md
+++ b/_basic/languages-frameworks/dart.md
@@ -9,7 +9,7 @@ menus:
     title: Dart
     weight: 8
 categories:
-  - Languages And Frameworks    
+  - Languages And Frameworks
 redirect_from:
   - /languages/dart/
 ---
@@ -46,7 +46,7 @@ We do not cache Dart dependencies between builds by default, but any dependencie
 
 ## Frameworks And Testing
 
-As dart currently doesn't have a default way to run your tests you can use exactly the same command to run those tests as you would on your local machine. Note that almost all tools that do not require root access for custom machine configuration will install and run without issue on Codeship.
+As dart currently doesn't have a default way to run your tests you can use exactly the same command to run those tests as you would on your local machine. Note that almost all tools for custom machine configuration will install and run without issue on Codeship.
 
 ### Browser testing
 

--- a/_basic/languages-frameworks/go.md
+++ b/_basic/languages-frameworks/go.md
@@ -9,7 +9,7 @@ menus:
     title: Go
     weight: 6
 categories:
-  - Languages And Frameworks    
+  - Languages And Frameworks
 redirect_from:
   - /languages/go/
 ---
@@ -58,7 +58,7 @@ We do not cache Go dependencies between builds.
 
 ## Frameworks And Testing
 
-We support all Go tools and test frameworks, sas long as they do not require root access for custom machine configuration. You can run your tests with a standard `go test -v` or by using test frameworks such as gocheck.
+We support all Go tools and test frameworks. You can run your tests with a standard `go test -v` or by using test frameworks such as gocheck.
 
 For example, using gocheck would look like:
 

--- a/_basic/languages-frameworks/java-and-jvm-based-languages.md
+++ b/_basic/languages-frameworks/java-and-jvm-based-languages.md
@@ -20,7 +20,7 @@ menus:
     title: Java And JVM
     weight: 7
 categories:
-  - Languages And Frameworks    
+  - Languages And Frameworks
 redirect_from:
   - /languages/java-and-jvm-based-languages/
 ---
@@ -136,7 +136,7 @@ Codeship automatically caches the `$HOME/.ivy2` and `$HOME/.m2/repository` direc
 
 ## Frameworks And Testing
 
-All build tools and test frameworks, such as [JUnit](https://junit.org), will work without issue as long as they do not require root access for custom machine configuration.
+All build tools and test frameworks, such as [JUnit](https://junit.org), will work.
 
 ## Parallel Testing
 

--- a/_basic/languages-frameworks/meteor.md
+++ b/_basic/languages-frameworks/meteor.md
@@ -11,7 +11,7 @@ tags:
   - yarn
   - framework
 categories:
-  - Languages And Frameworks  
+  - Languages And Frameworks
 ---
 
 * include a table of contents
@@ -19,10 +19,10 @@ categories:
 
 ## Setup
 
-Meteor's default installer requires sudo on Linux. We use a script to change install location and make sudo unnecessary:
+First run Meteor's default installer:
 
 ```shell
-\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/meteor.sh | bash -s
+\curl https://install.meteor.com/ | sh
 ```
 
 ### Custom Versions

--- a/_basic/languages-frameworks/php.md
+++ b/_basic/languages-frameworks/php.md
@@ -137,7 +137,7 @@ composer install --prefer-dist --no-interaction
 
 ## Frameworks And Testing
 
-Codeship supports essentially all popular PHP frameworks, such as Laravel, Symfony, CodeIgniter and CakePHP. All frameworks that do not require root access for custom machine configuration should work without issue.
+Codeship supports essentially all popular PHP frameworks, such as Laravel, Symfony, CodeIgniter and CakePHP.
 
 Additionally, all testing frameworks, such as phpunit and codeception, will work on Codeship.
 

--- a/_basic/languages-frameworks/python.md
+++ b/_basic/languages-frameworks/python.md
@@ -64,7 +64,7 @@ Codeship automatically caches all dependencies installed through `pip`. You can 
 
 ## Frameworks And Testing
 
-All Python frameworks, including Django, Flask and Pyramid, should work without issue as long as they do not require root-access for customized system configuration.
+All Python frameworks, including Django, Flask and Pyramid, should work without issue.
 
 All test frameworks and tools, including pytest and unittest, should also work without issue.
 

--- a/_basic/languages-frameworks/ruby.md
+++ b/_basic/languages-frameworks/ruby.md
@@ -71,7 +71,7 @@ Codeship automatically configures bundler to use the `$HOME/cache/bundler` direc
 
 ## Frameworks And Testing
 
-Our Ruby support includes Ruby itself, [Rails](https://rubyonrails.org), [Sinatra](http://sinatrarb.com) and most other frameworks that do not require root-access for customized system configuration.
+Our Ruby support includes Ruby itself, [Rails](https://rubyonrails.org), [Sinatra](http://sinatrarb.com) and most other frameworks.
 
 We also support all Ruby based test frameworks like RSpec, Cucumber and Minitest.
 

--- a/_basic/services/elasticsearch.md
+++ b/_basic/services/elasticsearch.md
@@ -20,10 +20,6 @@ categories:
 
 [Elasticsearch](https://www.elastic.co) **1.2.2** is installed on the default port **9200** and doesn't require any credentials. However, it is not running by default. To use Elasticsearch during your builds, start the service with the following command:
 
-{% csnote warning %}
-This is one of the only commands available via `sudo` and root access to run any other commands is not available on the build VMs.
-{% endcsnote %}
-
 ```shell
 sudo /etc/init.d/elasticsearch start
 ```

--- a/_general/integrations/custom-integration.md
+++ b/_general/integrations/custom-integration.md
@@ -9,7 +9,7 @@ menus:
     title: Custom Integrations
     weight: 26
 categories:
-  - Integrations    
+  - Integrations
 ---
 
 * include a table of contents
@@ -67,9 +67,9 @@ You can do this by navigating to _Project Settings_ and then clicking on the _En
 
 ### Tooling And Environment
 
-Codeship Basic builds run on shared virtual machines with tooling preinstalled. A user can install any package that they need via the project's [setup commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}), but may not install anything that requires `sudo` or root access.
+Codeship Basic builds run on shared virtual machines with tooling preinstalled. A user can install any package that they need via the project's [setup commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}), including anything that requires `sudo` or root access.
 
-As an example if your project has a CLI that is required to be installed for the tool's commands to execute, you will need to install the CLI (without `sudo` or root) via the project's [setup commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) so that you may call the commands you need in the [test commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) section.
+As an example if your project has a CLI that is required to be installed for the tool's commands to execute, you will need to install the CLI (potentially using `sudo`) via the project's [setup commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) so that you may call the commands you need in the [test commands]({{ site.baseurl }}{% link _basic/quickstart/getting-started.md %}) section.
 
 ### Executing Commands
 


### PR DESCRIPTION
realized we had multiple references to e.g. "sudo is not available" or "use this script to avoid sudo" etc.