### PR TITLE
Skip checking canonical links with HTMLProofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,10 @@ task :htmlproofer do
     },
     :http_status_ignore => [999],
     :file_ignore => [/google1a85968316265362.html/],
-    :url_ignore => [/xip.io/]
+    :url_ignore => [/xip.io/],
+    :url_swap => {
+      'https://documentation.codeship.com' => '',
+    }
   }
   HTMLProofer.check_directory("/site/htmlproofer", options).run
   FileUtils.rm_rf("/site/htmlproofer")


### PR DESCRIPTION
Updates HTMLProofer to skip checking canonical links.

This is a [known issue](https://github.com/gjtorikian/html-proofer/issues/170) with the tool and this PR [implements the fix](https://github.com/gjtorikian/html-proofer/issues/170#issuecomment-384980061) using the `url_swap` option to make the canonical link relative instead of absolute.

Now HTMLProofer should pass when adding a new article or adding a new tag to an existing article.