### PR TITLE
Manual approval updates

### DIFF
--- a/_basic/languages-frameworks/rust.md
+++ b/_basic/languages-frameworks/rust.md
@@ -19,7 +19,7 @@ categories:
 
 ## Versions And Setup
 
-[Rust](https://www.rust-lang.org/en-US) is not installed on the build VMs by default, but it can be easily added with a script.
+[Rust](https://www.rust-lang.org) is not installed on the build VMs by default, but it can be easily added with a script.
 
 To install the latest Rust version add [this command](https://github.com/codeship/scripts/blob/master/languages/rust.sh#L6) to your _Setup Commands_ and the script will automatically be called at build time.
 

--- a/_pro/builds-and-configuration/steps.md
+++ b/_pro/builds-and-configuration/steps.md
@@ -271,6 +271,11 @@ There are several important things to note when using manual steps:
 
 ![Manual approval step group]({{ site.baseurl }}/images/general/manual-approval.png)
 
+{% csnote info %}
+  Approvals are per commit, which means that if multiple builds on the same branch are paused, waiting for approval, you could just approve the latest one if you want to allow the final step to run for all previous changes. There's no need to approve each build.
+{% endcsnote %}
+
+
 ## Build Environment
 
 For each step, the running container is provided with a set of environment variables from the CI process. These values can help your containers to make decisions based on your build pipeline.


### PR DESCRIPTION
Feedback from a customer was that it wasn't clear that you didn't have to approve every paused build to get all the changes out.
This is more of a stop-gap as it's likely more of a UX issue than a documentation issue