### PR TITLE
Remove Google+ link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,11 +63,6 @@
       </a>
     </li>
     <li>
-      <a target="_blank" href="https://plus.google.com/104419910257777182146/posts">
-        <span class="icon fa fa-google-plus"></span>Google +
-      </a>
-    </li>
-    <li>
       <a target="_blank" href="https://www.linkedin.com/company/codeship">
         <span class="icon fa fa-linkedin"></span>LinkedIn
       </a>


### PR DESCRIPTION
The Codeship account has been shut down and the link now gives a 404