### PR TITLE
Remove CasperJS

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -113,7 +113,6 @@ cakephp
 capistranorb.com
 capybara-webkit
 caskroom
-casperjs
 ccmenu
 changelog
 check_url

--- a/_basic/continuous-integration/browser-testing.md
+++ b/_basic/continuous-integration/browser-testing.md
@@ -133,14 +133,6 @@ To install the latest [SlimerJS](https://slimerjs.org) version [install a compat
 npm install slimerjs
 ```
 
-## CasperJS
-
-To install the latest [CasperJS](http://casperjs.org) version add the following command to your build steps:
-
-```
-npm install casperjs
-```
-
 ## Screenshots
 
 During your tests you may want to generate screenshots when tests fail. Codeship Basic starts a new build machine for each build and that machine gets terminated as soon as the build finishes. As a result there is not a simple way to save screenshots from failing builds.

--- a/_general/about/getting_started_with_ci.md
+++ b/_general/about/getting_started_with_ci.md
@@ -37,4 +37,3 @@ Read more on CI/CD in the [Codeship Integration Essentials](https://codeship.com
 * [Why Continuous Deployment by Eric Ries](https://www.startuplessonslearned.com/2009/06/why-continuous-deployment.html)
 * [A Business Case for Continuous Integration](https://blog.codeship.com/benefits-of-continuous-integration/)
 * [How to start with testing from top to bottom](https://blog.codeship.com/testing-top-to-bottom/)
-* [Start testing your website with Casperjs](https://blog.codeship.com/casperjs-examples/)


### PR DESCRIPTION
The CasperJS site is down (maybe permanently?) and the GitHub repo indicates it is no longer maintained: https://github.com/casperjs/casperjs