### PR TITLE
Fix repeated word typos

### DIFF
--- a/_general/integrations/codeclimate.md
+++ b/_general/integrations/codeclimate.md
@@ -191,7 +191,7 @@ All of these commands will work best when executed from script files.
 
 Because of a bug with version 0.8.x of simplecov, tests are reported as successful, even though they actually failed. This is caused by simplecov overriding the exit code of the test framework.
 
-According the the [issue report on GitHub](https://github.com/colszowka/simplecov/issues/281) this won't be fixed in the 0.8 release. Please either use versions prior to 0.8 or higher than 0.9.
+According the [issue report on GitHub](https://github.com/colszowka/simplecov/issues/281) this won't be fixed in the 0.8 release. Please either use versions prior to 0.8 or higher than 0.9.
 
 ### Still having trouble setting up your Test Reporter?
 

--- a/_general/integrations/rancher.md
+++ b/_general/integrations/rancher.md
@@ -44,7 +44,7 @@ You will add these encrypted environment variables to the service you create bel
 
 ## Defining Your Service
 
-Because all the commands in your pipeline, via your [codeship-steps.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}), are executed inside the service you define and build build via your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}) - the first thing you will need to do is define a service that is capable of executing Rancher commands (and, specifically Rancher Compose commands.)
+Because all the commands in your pipeline, via your [codeship-steps.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/steps.md %}), are executed inside the service you define and build via your [codeship-services.yml file]({{ site.baseurl }}{% link _pro/builds-and-configuration/services.md %}) - the first thing you will need to do is define a service that is capable of executing Rancher commands (and, specifically Rancher Compose commands.)
 
 You can use an [existing image with Rancher compose configured](https://hub.docker.com/r/bfosberry/rancher-compose/) or build your own with a Dockerfile that looks similar to the one below:
 

--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -46,7 +46,7 @@ Make sure a webhook for Codeship is added under the _Webhooks_ section in the se
 
 ### Bitbucket
 
-Make sure a webhook for Codeship is added under the _Webhooks_ section in the settings of your repository. Please also check the the UUID in the hook URL matches the UUID from your project. The hook URL itself should match the following pattern.
+Make sure a webhook for Codeship is added under the _Webhooks_ section in the settings of your repository. Please also check the UUID in the hook URL matches the UUID from your project. The hook URL itself should match the following pattern.
 
 ```
 https://lighthouse.codeship.io/bitbucket_v2/YOUR_PROJECT_UUID

--- a/_pro/quickstart/docker-101.md
+++ b/_pro/quickstart/docker-101.md
@@ -8,7 +8,7 @@ menus:
 categories:
   - Quickstart
   - Docker
-  - Guide   
+  - Guide
 tags:
   - docker
   - jet
@@ -36,7 +36,7 @@ However, teams not using Docker can still make use of the flexibility offered by
 
 ## What Is Docker?
 
-Docker is a technology product, created by [Docker Inc.](https://www.docker.com), based on the [open-source Moby project](https://mobyproject.org). Docker is a tool to build and and run applications inside of containers based on Docker images, which is a portable and reusable file that launches an almost full-stack application environment.
+Docker is a technology product, created by [Docker Inc.](https://www.docker.com), based on the [open-source Moby project](https://mobyproject.org). Docker is a tool to build and run applications inside of containers based on Docker images, which is a portable and reusable file that launches an almost full-stack application environment.
 
 For more information, [visit Docker's "What Is Docker?" page](https://www.docker.com/what-docker).
 


### PR DESCRIPTION
Hi,

While testing an [open-source tool](https://github.com/errata-ai/vale) I'm developing, I came across a few instances of repeated words in your documentation. I went ahead and fixed the obvious cases in the PR, but there are a few more:

```console
 _general/integrations/percy.md
 71:144   error  'integration' is repeated!  vale.Repetition 
 79:104   error  'integration' is repeated!  vale.Repetition 
 117:144  error  'integration' is repeated!  vale.Repetition 
 127:94   error  'integration' is repeated!  vale.Repetition 
```
In the cases above, it appears that the issue may be an incorrect word (i.e., should it be "*integration instructions*"?):

> You can find specific integration integration for calling Percy from your test specs [at the Percy documentation](https://percy.io/docs/clients/ruby/capybara-rails).