### PR TITLE
Update google-cloud-functions.md

### DIFF
--- a/_pro/continuous-deployment/google-cloud-functions.md
+++ b/_pro/continuous-deployment/google-cloud-functions.md
@@ -67,7 +67,7 @@ Because each step runs in a separate group of containers, you will likely want t
 ```yaml
 - name: google-cloud-deployment
   service: googleclouddeployment
-  command: google-deploy.sh
+  command: /deploy/google-deploy.sh
 ```
 
 Inside this deployment script will be all commands you want to run via the Google Cloud or Kubernetes CLI, both included in the [deployment image that we maintain]((https://hub.docker.com/r/codeship/google-cloud-deployment/).


### PR DESCRIPTION
running command `google-deploy.sh` without any file pathing will fail with "executable not found in $PATH" messaging