### PR TITLE
Address bundler warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    ffi (1.9.25)
+    ffi (1.10.0)
     forwardable-extended (2.6.0)
     html-proofer (3.10.2)
       activesupport (>= 4.2, < 6.0)
@@ -87,7 +87,7 @@ GEM
     minitest (5.11.3)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.13.0)
+    parallel (1.14.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
@@ -102,14 +102,14 @@ GEM
       ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
+    sassc (2.0.1)
+      ffi (~> 1.9)
       rake
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
@@ -143,4 +143,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.3
+   1.17.2


### PR DESCRIPTION
Addresses [image build warning](https://app.codeship.com/projects/102044/builds/ee1a88e6-e478-48f2-bdee-6ee416fa52dd?line=61f3005d-dfb9-4fc9-82f1-ead6e9fc65bd&service=documentation) by ensuring Gemfile.lock is generated with version of Bundler present in image.