### PR TITLE
Remove Instagram link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -58,11 +58,6 @@
       </a>
     </li>
     <li>
-      <a target="_blank" href="https://www.instagram.com/codeship/">
-        <span class="icon fa fa-instagram"></span>Instagram
-      </a>
-    </li>
-    <li>
       <a target="_blank" href="https://www.linkedin.com/company/codeship">
         <span class="icon fa fa-linkedin"></span>LinkedIn
       </a>


### PR DESCRIPTION
The Codeship account has been shut down and the link now gives a 404