### PR TITLE
set version of bundler to 1.17.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,4 +143,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.3
+   1.17.2


### PR DESCRIPTION
Addresses [image build warning](https://app.codeship.com/projects/102044/builds/ee1a88e6-e478-48f2-bdee-6ee416fa52dd?line=61f3005d-dfb9-4fc9-82f1-ead6e9fc65bd&service=documentation) by ensuring Gemfile.lock is generated with version of Bundler present in image.