### PR TITLE
Ignore checking nip.io link

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ task :htmlproofer do
     },
     :http_status_ignore => [999],
     :file_ignore => [/google1a85968316265362.html/],
-    :url_ignore => [/xip.io/],
+    :url_ignore => [/nip.io/, /xip.io/],
     :url_swap => {
       'https://documentation.codeship.com' => '',
     }


### PR DESCRIPTION
This link is frequently down so will have HTMLProofer ignore it