### PR TITLE
Remove Facebook link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,11 +63,6 @@
       </a>
     </li>
     <li>
-      <a target="_blank" href="https://www.facebook.com/codeship/">
-        <span class="icon fa fa-facebook"></span>Facebook
-      </a>
-    </li>
-    <li>
       <a target="_blank" href="https://www.youtube.com/channel/UCxc5i0d5pIJJeF39NFdCGRQ">
         <span class="icon fa fa-youtube"></span>YouTube
       </a>


### PR DESCRIPTION
The Codeship account has been shut down and the link now fails