### PR TITLE
Switch to Browserslist for Autoprefixer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ var site = '/site/';
 gulp.task('css', folders(site, function(folder) {
 	var processors = [
 		autoprefixer({
-			browsers: ['last 2 versions', '> 5%']
 		})
 	];
 

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "gulp-jsonlint": "^1.3.0",
     "gulp-postcss": "^8.0.0",
     "markdown-spellcheck": "^1.3.1"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "> 5%"
+  ]
 }


### PR DESCRIPTION
The [update](https://github.com/codeship/documentation/pull/1524) to [Autoprefixer 9.6.0](https://github.com/postcss/autoprefixer/releases/tag/9.6.0) introduced an upcoming deprecation on the `post-process` step of the build:

> Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

> Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

> If you really need to use option, rename it to overrideBrowserslist.

> Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist

This should resolve it by moving to the Browserslist configuration.