### PR TITLE
Last of the Codeship to CodeShip for product indicator

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -17,11 +17,11 @@ layout: default
 
         <div class="product-indicator">
           {% if page.collection == "pro" %}
-            <span class="product-pro">This article is about <a href="https://codeship.com/features/pro">Codeship Pro</a>.</span>
+            <span class="product-pro">This article is about <a href="https://codeship.com/features/pro">CodeShip Pro</a>.</span>
           {% elsif page.collection == "basic" %}
-            <span class="product-basic">This article is about <a href="https://codeship.com/features/basic">Codeship Basic</a>.</span>
+            <span class="product-basic">This article is about <a href="https://codeship.com/features/basic">CodeShip Basic</a>.</span>
           {% elsif page.collection == "general" %}
-            <span class="product-general">This article is about <a href="https://codeship.com/features">General Codeship Configuration</a>.</span>
+            <span class="product-general">This article is about <a href="https://codeship.com/features">General CodeShip Configuration</a>.</span>
           {% endif %}
         </div>
 


### PR DESCRIPTION
This will fix all the pages that specific "This article is for CodeShip *product_name*"