### PR TITLE
Ignore checking lftp.yar.ru links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ task :htmlproofer do
     },
     :http_status_ignore => [999],
     :file_ignore => [/google1a85968316265362.html/],
-    :url_ignore => [/nip.io/, /xip.io/],
+    :url_ignore => [/lftp.yar.ru/, /nip.io/, /xip.io/],
     :url_swap => {
       'https://documentation.codeship.com' => '',
     }


### PR DESCRIPTION
These links frequently have issues so will have HTMLProofer ignore them