### PR TITLE
Fix HTMLProofer scan

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ task :htmlproofer do
     },
     :http_status_ignore => [999],
     :file_ignore => [/google1a85968316265362.html/],
-    :url_ignore => [/lftp.yar.ru/, /nip.io/, /xip.io/],
+    :url_ignore => [/lftp.yar.ru/, /nip.io/, /twitter.com/, /xip.io/],
     :url_swap => {
       'https://documentation.codeship.com' => '',
     }

--- a/_general/integrations/rollbar.md
+++ b/_general/integrations/rollbar.md
@@ -26,7 +26,7 @@ redirect_from:
 
 ## About Rollbar
 
-[Rollbar](https://www.rollbar.com) lets you collect and track errors and events related to your web applications. During your continuous deployment workflow with CodeShip Pro, you can use Rollbar to log information related to your deployments.
+[Rollbar](https://rollbar.com) lets you collect and track errors and events related to your web applications. During your continuous deployment workflow with CodeShip Pro, you can use Rollbar to log information related to your deployments.
 
 By using Rollbar you can track important logs for future analysis and alerting.
 


### PR DESCRIPTION
HTMLProofer has been failing recently. This fixes a Rollbar link and also ignores Twitter links. Twitter started returning 429 rate limit errors recently because this is likely trying to test too many Twitter links at once during the scan.