### PR TITLE
[SHIP-2671] Documentation - Update App URL

### DIFF
--- a/_general/projects/builds-are-not-triggered.md
+++ b/_general/projects/builds-are-not-triggered.md
@@ -42,7 +42,7 @@ Make sure the CodeShip GitHub app is installed on your GitHub organization that 
 
 #### Reinstall GitHub App
 
-To reset the installation, you can uninstall and reinstall the app. Under the same _Configure_ page as above, scroll to the bottom and click the _Uninstall_ button. Once GitHub finishes removing the app, you can [install](https://github.com/apps/codeship/installations/new) it in your organization again.
+To reset the installation, you can uninstall and reinstall the app. Under the same _Configure_ page as above, scroll to the bottom and click the _Uninstall_ button. Once GitHub finishes removing the app, you can [install](https://github.com/apps/cloudbees/installations/new) it in your organization again.
 
 ### GitLab
 


### PR DESCRIPTION
For the Mothership-Documentation repo, changes the GitHub app URL from https://github.com/apps/codeship

to:

https://github.com/apps/cloudbees